### PR TITLE
[MIPR-1284] Add connector to retrieve BTA Nav Content (links)

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
@@ -44,6 +44,8 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
     if (isEnabled(UseStubForBackend)) s"${servicesConfig.baseUrl("income-tax-penalties-stubs")}/income-tax-penalties-stubs"
     else servicesConfig.baseUrl("message-frontend")
 
+  def btaBaseUrl: String = servicesConfig.baseUrl("business-tax-account")
+
   val appName: String = servicesConfig.getString("appName")
 
   def appealLPPDataForPenaltyAndEnrolmentKey(penaltyId: String, enrolmentKey: String, isAdditional: Boolean): String = {

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/BtaNavLinksConnector.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/BtaNavLinksConnector.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors
+
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.httpParsers.BtaNavLinksHttpParser
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.btaNavBar.NavContent
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class BtaNavLinksConnector @Inject()(val http: HttpClientV2,
+                                     val config: AppConfig) extends BtaNavLinksHttpParser {
+
+  def getBtaNavLinks()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[NavContent]] = {
+    logger.debug(s"[BtaNavLinksConnector][getBtaNavLinks] - Requesting NavLinks from BTA")
+    http
+      .get(url"${config.btaBaseUrl}/business-account/partial/nav-links")
+      .execute[Option[NavContent]]
+  }
+
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/httpParsers/BtaNavLinksHttpParser.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/httpParsers/BtaNavLinksHttpParser.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.httpParsers
+
+import play.api.http.Status._
+import play.api.libs.json.{JsError, JsSuccess}
+import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.btaNavBar.NavContent
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.PagerDutyHelper
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.PagerDutyHelper.PagerDutyKeys.{INVALID_JSON_RECEIVED_FROM_BTA, RECEIVED_4XX_FROM_BTA, RECEIVED_5XX_FROM_BTA}
+
+trait BtaNavLinksHttpParser {
+
+  implicit object BtaNavLinksReads extends HttpReads[Option[NavContent]] {
+    override def read(method: String, url: String, response: HttpResponse): Option[NavContent] =
+      response.status match {
+        case OK =>
+          logger.debug(s"[BtaNavLinksReads][read] Successful call to retrieve BTA Nav Links. Response: \n\n ${response.json}")
+          response.json.validateOpt[NavContent] match {
+            case JsSuccess(navLinks, _) =>
+              navLinks
+            case JsError(errors) =>
+              PagerDutyHelper.log("BtaNavLinksHttpParser: BtaNavLinksReads", INVALID_JSON_RECEIVED_FROM_BTA)
+              logger.debug(s"[BtaNavLinksReads][read] Failed to parse response from BTA to NavLinks model - failures: $errors")
+              logger.error("[BtaNavLinksReads][read] Failed to parse response from BTA to NavLinks model, returning None to continue gracefully")
+              None
+          }
+        case status =>
+          PagerDutyHelper.logStatusCode("BtaNavLinksHttpParser: BtaNavLinksReads", status)(RECEIVED_4XX_FROM_BTA, RECEIVED_5XX_FROM_BTA)
+          logger.error(s"[BtaNavLinksReads][read] Received unexpected response when calling BTA for NavLinks" +
+            s", status code: $status and body: ${response.body}, returning None to continue gracefully")
+          None
+      }
+  }
+}
+

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/btaNavBar/NavContent.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/btaNavBar/NavContent.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.btaNavBar
+
+import play.api.libs.json.{Format, Json}
+
+case class NavContent(home: NavLink,
+                      account: NavLink,
+                      messages: NavLink,
+                      help: NavLink,
+                      forms: NavLink)
+
+object NavContent {
+  implicit val format: Format[NavContent] = Json.format[NavContent]
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/btaNavBar/NavLink.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/btaNavBar/NavLink.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.btaNavBar
+
+import play.api.libs.json.{Format, Json}
+
+case class NavLink(en: String,
+                   cy: String,
+                   url: String,
+                   alerts: Option[Int] = None)
+
+object NavLink {
+  implicit val format: Format[NavLink] = Json.format[NavLink]
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/PagerDutyHelper.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/PagerDutyHelper.scala
@@ -26,6 +26,9 @@ object PagerDutyHelper {
     final val RECEIVED_4XX_FROM_MESSAGE_FRONTEND = Value
     final val RECEIVED_5XX_FROM_MESSAGE_FRONTEND = Value
     final val INVALID_JSON_RECEIVED_FROM_MESSAGE_FRONTEND = Value
+    final val RECEIVED_4XX_FROM_BTA = Value
+    final val RECEIVED_5XX_FROM_BTA = Value
+    final val INVALID_JSON_RECEIVED_FROM_BTA = Value
     final val RECEIVED_4XX_FROM_UPSCAN = Value
     final val RECEIVED_5XX_FROM_UPSCAN = Value
     final val FILE_UPLOAD_STATUS_NOT_FOUND_UPSCAN = Value

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -64,6 +64,11 @@ microservice {
       host = localhost
       port = 9060
     }
+    business-tax-account {
+      protocol = http
+      host = localhost
+      port = 9020
+    }
     auth {
       host = localhost
       port = 8500

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/BtaNavLinkConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/BtaNavLinkConnectorISpec.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors
+
+import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR}
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.fixtures.BtaNavContentFixture
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.PagerDutyHelper.PagerDutyKeys
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, WiremockMethods}
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
+
+import scala.concurrent.ExecutionContext
+
+class BtaNavLinkConnectorISpec extends ComponentSpecHelper with LogCapturing with WiremockMethods with BtaNavContentFixture {
+
+  val connector: BtaNavLinksConnector = app.injector.instanceOf[BtaNavLinksConnector]
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+  implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  "getBtaNavLinks" should {
+    "return Some(NavContent)" when {
+      "a successful response when the call succeeds and the body can be parsed" in {
+        when(GET, uri = "/business-account/partial/nav-links").thenReturn(status = OK, body = btaNavContent)
+        await(connector.getBtaNavLinks()) shouldBe Some(btaNavContent)
+      }
+    }
+
+    "return None" when {
+      "a successful response with no body is returned" in {
+        when(GET, uri = "/business-account/partial/nav-links").thenReturn(status = OK, body = "")
+        await(connector.getBtaNavLinks()) shouldBe None
+      }
+
+      "a 4xx is returned" in {
+        when(GET, uri = "/business-account/partial/nav-links").thenReturn(status = BAD_REQUEST, body = Json.obj())
+        withCaptureOfLoggingFrom(logger) {
+          logs => {
+            val result = await(connector.getBtaNavLinks())
+            logs.exists(_.getMessage.contains(PagerDutyKeys.RECEIVED_4XX_FROM_BTA.toString)) shouldBe true
+            result shouldBe None
+          }
+        }
+      }
+
+      "a 5xx is returned" in {
+        when(GET, uri = "/business-account/partial/nav-links").thenReturn(status = INTERNAL_SERVER_ERROR, body = Json.obj())
+        withCaptureOfLoggingFrom(logger) {
+          logs => {
+            val result = await(connector.getBtaNavLinks())
+            logs.exists(_.getMessage.contains(PagerDutyKeys.RECEIVED_5XX_FROM_BTA.toString)) shouldBe true
+            result shouldBe None
+          }
+        }
+      }
+    }
+  }
+}

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/fixtures/BtaNavContentFixture.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/fixtures/BtaNavContentFixture.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.fixtures
+
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.btaNavBar.{NavContent, NavLink}
+
+trait BtaNavContentFixture {
+
+  val btaNavLink: NavLink = NavLink(
+    en = "Foo",
+    cy = "Bar",
+    url = "/url",
+    alerts = Some(0)
+  )
+
+  val btaNavContent: NavContent = NavContent(
+    home = btaNavLink,
+    account = btaNavLink,
+    messages = btaNavLink,
+    help = btaNavLink,
+    forms = btaNavLink
+  )
+
+}

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/ComponentSpecHelper.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/ComponentSpecHelper.scala
@@ -59,6 +59,8 @@ trait ComponentSpecHelper
     "microservice.services.auth.port" -> mockPort,
     "microservice.services.message-frontend.host" -> mockHost,
     "microservice.services.message-frontend.port" -> mockPort,
+    "microservice.services.business-tax-account.host" -> mockHost,
+    "microservice.services.business-tax-account.port" -> mockPort,
     "auditing.enabled" -> "true",
     "play.filters.csrf.header.bypassHeaders.Csrf-Token" -> "nocheck"
   )


### PR DESCRIPTION
Notes:
- Adds connector and HTTP parser to retrieve the Nav Content (links) from BTA partials
- If no content is returned or an error occurs then a `None` is returned so that the frontend continues gracefully, this is the same as how V&C handle this.

app-config-base PR:
- https://github.com/hmrc/app-config-base/pull/11485