### PR TITLE
[MIPR-1283] Added connector to get unread messages count from message-frontend

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
@@ -40,6 +40,10 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
     if (isEnabled(UseStubForBackend)) s"${servicesConfig.baseUrl("income-tax-penalties-stubs")}/income-tax-penalties-stubs"
     else s"${servicesConfig.baseUrl("penalties")}/penalties"
 
+  def messagesFrontendBaseUrl: String =
+    if (isEnabled(UseStubForBackend)) s"${servicesConfig.baseUrl("income-tax-penalties-stubs")}/income-tax-penalties-stubs"
+    else servicesConfig.baseUrl("message-frontend")
+
   val appName: String = servicesConfig.getString("appName")
 
   def appealLPPDataForPenaltyAndEnrolmentKey(penaltyId: String, enrolmentKey: String, isAdditional: Boolean): String = {

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/MessageCountConnector.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/MessageCountConnector.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors
+
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.httpParsers.MessageCountHttpParser.GetMessageCountResponse
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class MessageCountConnector @Inject()(httpClient: HttpClientV2,
+                                      val appConfig: AppConfig) {
+
+  def getMessageCount()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[GetMessageCountResponse] =
+    httpClient
+      .get(url"${appConfig.messagesFrontendBaseUrl}/messages/count?read=No")
+      .execute[GetMessageCountResponse]
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/httpParsers/MessageCountHttpParser.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/httpParsers/MessageCountHttpParser.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.httpParsers
+
+import play.api.http.Status._
+import play.api.libs.json.{JsError, JsSuccess}
+import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.messageCount.MessageCount
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.PagerDutyHelper
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.PagerDutyHelper.PagerDutyKeys.{INVALID_JSON_RECEIVED_FROM_MESSAGE_FRONTEND, RECEIVED_4XX_FROM_MESSAGE_FRONTEND, RECEIVED_5XX_FROM_MESSAGE_FRONTEND}
+
+object MessageCountHttpParser {
+
+  sealed trait MessagesCountFailure {
+    val message: String
+  }
+
+  case class MessagesCountUnexpectedFailure(status: Int) extends MessagesCountFailure {
+    override val message: String = s"Unexpected response, status $status returned when retrieving messages count"
+  }
+
+  case object MessagesCountResponseBadRequest extends MessagesCountFailure {
+    override val message: String = "A bad request was returned when calling message-frontend for messages count"
+  }
+
+  case object MessagesCountResponseMalformed extends MessagesCountFailure {
+    override val message: String = "Response body received from message-frontend for messages count was malformed"
+  }
+
+  type GetMessageCountResponse = Either[MessagesCountFailure, MessageCount]
+
+  implicit object GetMessageCount extends HttpReads[GetMessageCountResponse] {
+    override def read(method: String, url: String, response: HttpResponse): GetMessageCountResponse =
+      response.status match {
+        case OK =>
+          response.json.validate[MessageCount] match {
+            case JsSuccess(model, _) =>
+              logger.info(s"[GetMessageCount][read] Successful call to retrieve messages count, count was: ${model.count}.")
+              Right(model)
+            case JsError(errors) =>
+              logger.debug(s"[GetMessageCount][read] Failed to parse messages count response from message-frontend to MessageCount model - failures: $errors")
+              logger.error("[GetMessageCount][read] Failed to parse messages count response from message-frontend to MessageCount model")
+              PagerDutyHelper.log("MessageCountHttpParser: GetMessageCount", INVALID_JSON_RECEIVED_FROM_MESSAGE_FRONTEND)
+              Left(MessagesCountResponseMalformed)
+          }
+        case BAD_REQUEST =>
+          logger.error(s"[GetMessageCount][read]: Bad request returned with reason: ${response.body}")
+          PagerDutyHelper.log("MessageCountHttpParser: GetMessageCount", RECEIVED_4XX_FROM_MESSAGE_FRONTEND)
+          Left(MessagesCountResponseBadRequest)
+        case status =>
+          logger.error(s"[GetMessageCount][read]: Unexpected response, status $status returned with reason: ${response.body}")
+          PagerDutyHelper.logStatusCode("MessageCountHttpParser: GetMessageCount", status)(RECEIVED_4XX_FROM_MESSAGE_FRONTEND, RECEIVED_5XX_FROM_MESSAGE_FRONTEND)
+          Left(MessagesCountUnexpectedFailure(status))
+      }
+  }
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/messageCount/MessageCount.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/messageCount/MessageCount.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.messageCount
+
+import play.api.libs.json.{Format, Json}
+
+case class MessageCount(count: Int)
+
+object MessageCount {
+  implicit val fmt: Format[MessageCount] = Json.format[MessageCount]
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/PagerDutyHelper.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/PagerDutyHelper.scala
@@ -23,6 +23,9 @@ object PagerDutyHelper {
   object PagerDutyKeys extends Enumeration {
     final val RECEIVED_4XX_FROM_PENALTIES = Value
     final val RECEIVED_5XX_FROM_PENALTIES = Value
+    final val RECEIVED_4XX_FROM_MESSAGE_FRONTEND = Value
+    final val RECEIVED_5XX_FROM_MESSAGE_FRONTEND = Value
+    final val INVALID_JSON_RECEIVED_FROM_MESSAGE_FRONTEND = Value
     final val RECEIVED_4XX_FROM_UPSCAN = Value
     final val RECEIVED_5XX_FROM_UPSCAN = Value
     final val FILE_UPLOAD_STATUS_NOT_FOUND_UPSCAN = Value

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -59,6 +59,11 @@ microservice {
       host = localhost
       port = 9182
     }
+    message-frontend {
+      protocol = http
+      host = localhost
+      port = 9060
+    }
     auth {
       host = localhost
       port = 8500

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/MessageCountConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/MessageCountConnectorISpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors
+
+import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR}
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.httpParsers.MessageCountHttpParser.{GetMessageCountResponse, MessagesCountResponseBadRequest, MessagesCountResponseMalformed, MessagesCountUnexpectedFailure}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.featureswitch.core.config.{FeatureSwitching, UseStubForBackend}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.messageCount.MessageCount
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.PagerDutyHelper.PagerDutyKeys
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, WiremockMethods}
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
+
+import scala.concurrent.ExecutionContext
+
+class MessageCountConnectorISpec extends ComponentSpecHelper with LogCapturing with WiremockMethods with FeatureSwitching {
+
+  val connector: MessageCountConnector = app.injector.instanceOf[MessageCountConnector]
+  override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+  implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    disable(UseStubForBackend)
+  }
+
+  "getMessageCount" should {
+    "return a successful Right response when the call succeeds and the body can be parsed" when {
+      "a message count is returned" in {
+        when(GET, uri = s"/messages/count\\?read=No").thenReturn(status = OK, body = MessageCount(1))
+
+        val result: GetMessageCountResponse = await(connector.getMessageCount())
+
+        result shouldBe Right(MessageCount(1))
+      }
+    }
+
+    "return a Left when" when {
+
+      "invalid Json is returned" in {
+        when(GET, uri = s"/messages/count\\?read=No").thenReturn(status = OK, body = "")
+
+        val result = await(connector.getMessageCount())
+
+        result shouldBe Left(MessagesCountResponseMalformed)
+      }
+
+      "a 4xx is returned" in {
+        when(GET, uri = s"/messages/count\\?read=No").thenReturn(status = BAD_REQUEST, body = Json.obj())
+
+        withCaptureOfLoggingFrom(logger) {
+          logs => {
+            val result = await(connector.getMessageCount())
+            logs.exists(_.getMessage.contains(PagerDutyKeys.RECEIVED_4XX_FROM_MESSAGE_FRONTEND.toString)) shouldBe true
+            result shouldBe Left(MessagesCountResponseBadRequest)
+          }
+        }
+      }
+
+      "a 5xx is returned" in {
+        when(GET, uri = s"/messages/count\\?read=No").thenReturn(status = INTERNAL_SERVER_ERROR, body = Json.obj())
+
+        withCaptureOfLoggingFrom(logger) {
+          logs => {
+            val result = await(connector.getMessageCount())
+            logs.exists(_.getMessage.contains(PagerDutyKeys.RECEIVED_5XX_FROM_MESSAGE_FRONTEND.toString)) shouldBe true
+            result shouldBe Left(MessagesCountUnexpectedFailure(INTERNAL_SERVER_ERROR))
+          }
+        }
+      }
+    }
+  }
+}

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/ComponentSpecHelper.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/ComponentSpecHelper.scala
@@ -57,6 +57,8 @@ trait ComponentSpecHelper
     "microservice.services.income-tax-penalties-stubs.port" -> mockPort,
     "microservice.services.auth.host" -> mockHost,
     "microservice.services.auth.port" -> mockPort,
+    "microservice.services.message-frontend.host" -> mockHost,
+    "microservice.services.message-frontend.port" -> mockPort,
     "auditing.enabled" -> "true",
     "play.filters.csrf.header.bypassHeaders.Csrf-Token" -> "nocheck"
   )


### PR DESCRIPTION
Notes:
- Adds connector and HTTP parser to retrieve the unread message count from `message-frontend`
- An investigation/decision on whether this is the right approach for the PTA message count needs to be confirmed still but can be reviewed and merged as-is for now and refactored later if need be - this matches the Acceptance Criteria for the JIRA story for now.

app-config-base PR:
- https://github.com/hmrc/app-config-base/pull/11488