### PR TITLE
[MIPR-1378] Some refactoring to support Pages to simplify UserAnswers. Store HonestyDeclarationPage value on submission.

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/BaseUserAnswersController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/BaseUserAnswersController.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
+
+import play.api.i18n.I18nSupport
+import play.api.libs.json.Reads
+import play.api.mvc.Result
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.ErrorHandler
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.Page
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait BaseUserAnswersController extends FrontendBaseController with I18nSupport {
+
+  val errorHandler: ErrorHandler
+
+  def withAnswer[A](page: Page[A])(f: A => Future[Result])
+                   (implicit user: CurrentUserRequestWithAnswers[_], reads: Reads[A], ec: ExecutionContext): Future[Result] =
+    user.userAnswers.getAnswer[A](page) match {
+      case Some(value) => f(value)
+      case None =>
+        logger.warn(s"[BaseUserAnswersController][withAnswer] No answer found for pageKey: ${page.key}, mtditid: ${user.mtdItId}")
+        //TODO: In future, redirect to a SessionTimeout page, or JourneyExpired page that the User can recover from???
+        errorHandler.internalServerErrorTemplate.map(InternalServerError(_))
+    }
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/HonestyDeclarationController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/HonestyDeclarationController.scala
@@ -39,19 +39,17 @@ class HonestyDeclarationController @Inject()(honestyDeclaration: HonestyDeclarat
                                             )(implicit ec: ExecutionContext, val appConfig: AppConfig) extends BaseUserAnswersController {
 
   def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>
-    withAnswer(ReasonableExcusePage) { reasonableExcuse =>
-      Future(Ok(honestyDeclaration(user.isAgent, reasonableExcuse)))
-    }.recover { _ =>
-      //TODO: Remove this recover block code, this is to prevent JTs breaking.
-      //      This is temporary backwards compatability to support the old Session based storage.
-      //      Once the ReasonableExcuse page has been updated to store the answer to UserAnswers this
-      //      recover block can be removed!
-      user.session.get(IncomeTaxSessionKeys.reasonableExcuse) match {
-        case Some(reasonableExcuse) =>
-          Ok(honestyDeclaration(user.isAgent, reasonableExcuse))
-        case _ =>
-          Redirect(routes.ReasonableExcuseController.onPageLoad())
-      }
+    //TODO: Remove this user.session code once the ReasonableExcuse page has been updated to store the answer to UserAnswers/
+    //      This is temporary backwards compatability to support the old Session based storage.
+    //      Once the ReasonableExcuse page has been updated to store the answer to UserAnswers this
+    //      must be removed!
+    user.session.get(IncomeTaxSessionKeys.reasonableExcuse) match {
+      case Some(reasonableExcuse) =>
+        Future(Ok(honestyDeclaration(user.isAgent, reasonableExcuse)))
+      case _ =>
+        withAnswer(ReasonableExcusePage) { reasonableExcuse =>
+          Future(Ok(honestyDeclaration(user.isAgent, reasonableExcuse)))
+        }
     }
   }
 

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/HonestyDeclarationController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/HonestyDeclarationController.scala
@@ -16,15 +16,13 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
-import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.featureswitch.core.config.FeatureSwitching
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{AuthAction, UserAnswersAction}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{HonestyDeclarationPage, ReasonableExcusePage}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.UserAnswersService
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.IncomeTaxSessionKeys
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.HonestyDeclarationPage
-import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.AuthAction
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.predicates.NavBarRetrievalAction
 
 import javax.inject.Inject
@@ -34,24 +32,33 @@ import scala.concurrent.{ExecutionContext, Future}
 class HonestyDeclarationController @Inject()(honestyDeclaration: HonestyDeclarationPage,
                                              val authorised: AuthAction,
                                              withNavBar: NavBarRetrievalAction,
-                                             override val controllerComponents: MessagesControllerComponents
-                                            )(implicit ec: ExecutionContext,
-                                              val appConfig: AppConfig) extends FrontendBaseController with I18nSupport {
+                                             withAnswers: UserAnswersAction,
+                                             userAnswersService: UserAnswersService,
+                                             override val controllerComponents: MessagesControllerComponents,
+                                             override val errorHandler: ErrorHandler
+                                            )(implicit ec: ExecutionContext, val appConfig: AppConfig) extends BaseUserAnswersController {
 
-  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar) { implicit currentUser =>
-    val optReasonableExcuse = currentUser.session.get(IncomeTaxSessionKeys.reasonableExcuse)
-
-    optReasonableExcuse match {
-      case Some(reasonableExcuse) =>
-        Ok(honestyDeclaration(currentUser.isAgent, reasonableExcuse))
-      case _ =>
-        Redirect(routes.ReasonableExcuseController.onPageLoad())
+  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>
+    withAnswer(ReasonableExcusePage) { reasonableExcuse =>
+      Future(Ok(honestyDeclaration(user.isAgent, reasonableExcuse)))
+    }.recover { _ =>
+      //TODO: Remove this recover block code, this is to prevent JTs breaking.
+      //      This is temporary backwards compatability to support the old Session based storage.
+      //      Once the ReasonableExcuse page has been updated to store the answer to UserAnswers this
+      //      recover block can be removed!
+      user.session.get(IncomeTaxSessionKeys.reasonableExcuse) match {
+        case Some(reasonableExcuse) =>
+          Ok(honestyDeclaration(user.isAgent, reasonableExcuse))
+        case _ =>
+          Redirect(routes.ReasonableExcuseController.onPageLoad())
+      }
     }
   }
 
-
-  def submit(): Action[AnyContent] = authorised { _ =>
-    Redirect(routes.WhenDidEventHappenController.onPageLoad())
+  def submit(): Action[AnyContent] = (authorised andThen withAnswers).async { implicit user =>
+    val updatedAnswers = user.userAnswers.setAnswer(HonestyDeclarationPage, true)
+    userAnswersService.updateAnswers(updatedAnswers).map { _ =>
+      Redirect(routes.WhenDidEventHappenController.onPageLoad())
+    }
   }
-
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationController.scala
@@ -20,7 +20,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.AuthAction
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.SessionService
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.UserAnswersService
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{IncomeTaxSessionKeys, UUIDGenerator}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
@@ -31,7 +31,7 @@ import scala.concurrent.ExecutionContext
 
 class InitialisationController @Inject()(val authorised: AuthAction,
                                          override val controllerComponents: MessagesControllerComponents,
-                                         userAnswersService: SessionService,
+                                         userAnswersService: UserAnswersService,
                                          uuid: UUIDGenerator
                                         )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
 
@@ -43,7 +43,7 @@ class InitialisationController @Inject()(val authorised: AuthAction,
     logger.debug(s"[InitialisationController][onPageLoad] Starting journey for penaltyId: $penaltyId, created journeyId: $journeyId")
 
     val answers = UserAnswers(journeyId)
-      .setAnswer(IncomeTaxSessionKeys.penaltyNumber, penaltyId)
+      .setAnswerForKey(IncomeTaxSessionKeys.penaltyNumber, penaltyId)
 
     userAnswersService.updateAnswers(answers).map { _ =>
       Redirect(routes.AppealStartController.onPageLoad())

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/predicates/UserAnswersAction.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/predicates/UserAnswersAction.scala
@@ -20,14 +20,14 @@ import play.api.mvc.Results.{InternalServerError, Redirect}
 import play.api.mvc.{ActionRefiner, Result}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{CurrentUserRequest, CurrentUserRequestWithAnswers}
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.SessionService
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.UserAnswersService
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.IncomeTaxSessionKeys
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class UserAnswersAction @Inject()(sessionService: SessionService,
+class UserAnswersAction @Inject()(sessionService: UserAnswersService,
                                   errorHandler: ErrorHandler,
                                   appConfig: AppConfig)
                                  (implicit val executionContext: ExecutionContext) extends ActionRefiner[CurrentUserRequest, CurrentUserRequestWithAnswers] {

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/session/UserAnswers.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/session/UserAnswers.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.Page
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
 import java.time.Instant
@@ -28,17 +29,17 @@ case class UserAnswers(
                         lastUpdated: Instant = Instant.now
                       ) {
 
-  def getAnswer[A](key: String)(implicit reads: Reads[A]): Option[A] = {
-    (data \ key).validate.fold(_ => None, Some(_))
-  }
+  def getAnswer[A](page: Page[A])(implicit reads: Reads[A]): Option[A] =
+    (data \ page.key).validate.fold(_ => None, Some(_))
 
-  def setAnswer[A](key: String, value: A)(implicit writes: Writes[A]): UserAnswers = {
+  def setAnswerForKey[A](key: String, value: A)(implicit writes: Writes[A]): UserAnswers =
     UserAnswers(journeyId, data ++ Json.obj(key -> value))
-  }
 
-  def removeAnswer(key: String): UserAnswers = {
-    UserAnswers(journeyId, data - key)
-  }
+  def setAnswer[A](page: Page[A], value: A)(implicit writes: Writes[A]): UserAnswers =
+    setAnswerForKey(page.key, value)
+
+  def removeAnswer[A](page: Page[A]): UserAnswers =
+    UserAnswers(journeyId, data - page.key)
 }
 
 object UserAnswers {

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/pages/HonestyDeclarationPage.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/pages/HonestyDeclarationPage.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages
+
+object HonestyDeclarationPage extends Page[Boolean] {
+  val key = "hasConfirmedDeclaration"
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/pages/Page.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/pages/Page.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages
+
+trait Page[A] {
+  val key: String
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/pages/ReasonableExcusePage.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/pages/ReasonableExcusePage.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages
+
+object ReasonableExcusePage extends Page[String] {
+  val key = "reasonableExcuse"
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealService.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealService.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.PenaltiesConnect
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.httpParsers.ErrorResponse
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.featureswitch.core.config.FeatureSwitching
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.{AppealSubmission, AppealSubmissionResponseModel, MultiplePenaltiesData}
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{AppealData, PenaltyTypeEnum, ReasonableExcuse}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{AppealData, CurrentUserRequestWithAnswers, PenaltyTypeEnum, ReasonableExcuse}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{EnrolmentUtil, IncomeTaxSessionKeys, TimeMachine, UUIDGenerator}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.PagerDutyHelper.PagerDutyKeys
@@ -92,7 +92,7 @@ class AppealService @Inject()(penaltiesConnector: PenaltiesConnector,
   def submitAppeal(reasonableExcuse: String,
                    mtdItId: String,
                    optArn: Option[String]
-                  )(implicit request: Request[_], ec: ExecutionContext, hc: HeaderCarrier): Future[Either[Int, Unit]] = {
+                  )(implicit request: CurrentUserRequestWithAnswers[_], ec: ExecutionContext, hc: HeaderCarrier): Future[Either[Int, Unit]] = {
 
     val appealType = request.session.get(IncomeTaxSessionKeys.appealType).map(PenaltyTypeEnum.withName)
     val isLPP = appealType.contains(PenaltyTypeEnum.Late_Payment) || appealType.contains(PenaltyTypeEnum.Additional)
@@ -107,7 +107,7 @@ class AppealService @Inject()(penaltiesConnector: PenaltiesConnector,
   private def singleAppeal(mtdItId: String, isLPP: Boolean,
                            agentReferenceNo: Option[String],
                            reasonableExcuse: String
-                          )(implicit request: Request[_], ec: ExecutionContext, hc: HeaderCarrier): Future[Either[Int, Unit]] = {
+                          )(implicit request: CurrentUserRequestWithAnswers[_], ec: ExecutionContext, hc: HeaderCarrier): Future[Either[Int, Unit]] = {
     val correlationId = idGenerator.generateUUID
     val modelFromRequest: AppealSubmission = AppealSubmission.constructModelBasedOnReasonableExcuse(reasonableExcuse, isAppealLate, agentReferenceNo, mtdItId)
     val penaltyNumber = request.session.get(IncomeTaxSessionKeys.penaltyNumber).getOrElse(throw new RuntimeException("[AppealService][singleAppeal] Penalty number not found in session"))
@@ -131,7 +131,7 @@ class AppealService @Inject()(penaltiesConnector: PenaltiesConnector,
 
   private def multipleAppeal(mtdItId: String, isLPP: Boolean,
                              agentReferenceNo: Option[String],
-                             reasonableExcuse: String)(implicit request: Request[_], ec: ExecutionContext, hc: HeaderCarrier): Future[Either[Int, Unit]] = {
+                             reasonableExcuse: String)(implicit request: CurrentUserRequestWithAnswers[_], ec: ExecutionContext, hc: HeaderCarrier): Future[Either[Int, Unit]] = {
 
     val firstCorrelationId = idGenerator.generateUUID
     val secondCorrelationId = idGenerator.generateUUID

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/UserAnswersService.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/UserAnswersService.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRep
 import javax.inject.Inject
 import scala.concurrent.Future
 
-class SessionService @Inject()(userAnswersRepository: UserAnswersRepository) {
+class UserAnswersService @Inject()(userAnswersRepository: UserAnswersRepository) {
 
   def getUserAnswers(journeyId: String): Future[Option[UserAnswers]] = {
     userAnswersRepository.getUserAnswer(journeyId)

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/IncomeTaxSessionKeys.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/IncomeTaxSessionKeys.scala
@@ -31,7 +31,6 @@ object IncomeTaxSessionKeys {
   val reasonableExcuse = "reasonableExcuse"
   val dateOfCrime = "dateOfCrime"
   val dateOfFireOrFlood = "dateOfFireOrFlood"
-  val hasConfirmedDeclaration = "hasConfirmedDeclaration"
   val hasCrimeBeenReportedToPolice = "hasCrimeBeenReportedToPolice"
   val lateAppealReason = "lateAppealReason"
   val whenPersonLeftTheBusiness = "whenPersonLeftTheBusiness"
@@ -84,7 +83,6 @@ object IncomeTaxSessionKeys {
     reasonableExcuse,
     dateOfCrime,
     dateOfFireOrFlood,
-    hasConfirmedDeclaration,
     hasCrimeBeenReportedToPolice,
     lateAppealReason,
     dateCommunicationSent,

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationControllerISpec.scala
@@ -36,19 +36,13 @@ class InitialisationControllerISpec extends ComponentSpecHelper with ViewSpecHel
 
   lazy val userAnswers: UserAnswersRepository = injector.instanceOf[UserAnswersRepository]
 
-  val testJourneyId: String = "journeyId123"
   val testDateTime: LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)
-
-  lazy val mockUUIDGenerator: UUIDGenerator = new UUIDGenerator {
-    override def generateUUID: String = testJourneyId
-  }
 
   lazy val mockDateTime: DateTimeHelper = new DateTimeHelper {
     override def dateTimeNow: LocalDateTime = testDateTime
   }
 
   override lazy val app: Application = appWithOverrides(
-    inject.bind[UUIDGenerator].toInstance(mockUUIDGenerator),
     inject.bind[DateTimeHelper].toInstance(mockDateTime)
   )
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/NavBarTesterHelper.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/NavBarTesterHelper.scala
@@ -26,13 +26,13 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.{AuthStub, BtaNavLink
 
 trait NavBarTesterHelper extends AnyWordSpec with BtaNavLinksStub with MessagesStub with BtaNavContentFixture { _: ComponentSpecHelper with AuthStub =>
 
-  def testNavBar(url: String, queryParams: Map[String, String] = Map.empty, reasonableExcuse: Option[String] = None)(runStubs: => Unit = ()): Unit = {
+  def testNavBar(url: String, queryParams: Map[String, String] = Map.empty, reasonableExcuse: Option[String] = None)(runStubsAndUserAnswersSetup: => Unit = ()): Unit = {
     "Checking the Navigation Bar" when {
       "the origin is PTA" should {
         "render the PTA content" in {
           stubAuth(OK, successfulIndividualAuthResponse)
           stubMessagesCount()(OK, Json.obj("count" -> 0))
-          runStubs
+          runStubsAndUserAnswersSetup
           val result = get(url, origin = Some("PTA"), queryParams = queryParams, reasonableExcuse = reasonableExcuse)
 
           result.status shouldBe OK
@@ -45,7 +45,7 @@ trait NavBarTesterHelper extends AnyWordSpec with BtaNavLinksStub with MessagesS
       "the origin is BTA" should {
         "render the BTA content" in {
           stubAuth(OK, successfulIndividualAuthResponse)
-          runStubs
+          runStubsAndUserAnswersSetup
           stubBtaNavLinks()(OK, Json.toJson(btaNavContent))
           val result = get(url, origin = Some("BTA"), queryParams = queryParams, reasonableExcuse = reasonableExcuse)
 
@@ -59,7 +59,7 @@ trait NavBarTesterHelper extends AnyWordSpec with BtaNavLinksStub with MessagesS
       "the origin is unknown" should {
         "render without a Nav" in {
           stubAuth(OK, successfulIndividualAuthResponse)
-          runStubs
+          runStubsAndUserAnswersSetup
           val result = get(url, origin = None, queryParams = queryParams, reasonableExcuse = reasonableExcuse)
 
           result.status shouldBe OK
@@ -73,7 +73,7 @@ trait NavBarTesterHelper extends AnyWordSpec with BtaNavLinksStub with MessagesS
       "the user is an Agent" should {
         "render without a Nav" in {
           stubAuth(OK, successfulAgentAuthResponse)
-          runStubs
+          runStubsAndUserAnswersSetup
           val result = get(url, isAgent = true, origin = None, queryParams = queryParams, reasonableExcuse = reasonableExcuse)
 
           result.status shouldBe OK

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/BaseUserAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/BaseUserAnswersControllerSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
+
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.http.Status.OK
+import play.api.mvc.Results.Ok
+import play.api.mvc.{MessagesControllerComponents, Result}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.ErrorHandler
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.Page
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class BaseUserAnswersControllerSpec extends AnyWordSpec with should.Matchers with GuiceOneAppPerSuite with LogCapturing {
+
+  implicit lazy val ec: ExecutionContext = ExecutionContext.global
+  lazy val errHandler: ErrorHandler = app.injector.instanceOf[ErrorHandler]
+
+  lazy val testBaseController: BaseUserAnswersController = new BaseUserAnswersController {
+    override val controllerComponents: MessagesControllerComponents = stubMessagesControllerComponents()
+    override val errorHandler: ErrorHandler = errHandler
+  }
+
+  val testPage: Page[String] = new Page[String] { val key: String = "testPageKey" }
+
+  val f: String => Future[Result] = { answer => Future.successful(Ok(answer)) }
+
+  "BaseUserAnswersController" when {
+
+    "calling .withAnswer()" when {
+
+      "an answer exists" should {
+
+        implicit val user: CurrentUserRequestWithAnswers[_] = CurrentUserRequestWithAnswers(
+          mtdItId = "123456789",
+          userAnswers = UserAnswers("1234").setAnswer(testPage, "foo")
+        )(FakeRequest())
+
+        "execute the function with that answer" in {
+
+          val result = testBaseController.withAnswer(testPage)(f)
+
+          status(result) shouldBe OK
+          contentAsString(result) shouldBe "foo"
+        }
+      }
+
+      "an answer does NOT exist" should {
+
+        implicit val user: CurrentUserRequestWithAnswers[_] = CurrentUserRequestWithAnswers(
+          mtdItId = "123456789",
+          userAnswers = UserAnswers("1234")
+        )(FakeRequest())
+
+        //TODO: In future, redirect to SessionTimeout, or JourneyExpired page???
+        "log an error and render an ISE" in {
+
+          withCaptureOfLoggingFrom(logger) { logs =>
+            val result = testBaseController.withAnswer(testPage)(f)
+
+            status(result) shouldBe INTERNAL_SERVER_ERROR
+            contentAsString(result) shouldBe await(errHandler.internalServerErrorTemplate).toString
+
+            logs.exists(_.getMessage.contains(s"[BaseUserAnswersController][withAnswer] No answer found for pageKey: ${testPage.key}, mtditid: ${user.mtdItId}"))
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealServiceSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealServiceSpec.scala
@@ -32,7 +32,9 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.PenaltiesConnector
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.httpParsers.{InvalidJson, UnexpectedFailure}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.{AppealSubmissionResponseModel, MultiplePenaltiesData}
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{AppealData, PenaltyTypeEnum, ReasonableExcuse}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{AppealData, CurrentUserRequestWithAnswers, PenaltyTypeEnum, ReasonableExcuse}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.HonestyDeclarationPage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{IncomeTaxSessionKeys, TimeMachine, UUIDGenerator}
 import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
@@ -51,55 +53,76 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
   val testMtdItId: String = "123456789"
+  val testJourneyId: String = "journeyId1"
 
-  val fakeRequestForCrimeJourney: Request[AnyContent] = FakeRequest().withSession(
-    IncomeTaxSessionKeys.reasonableExcuse -> "crime",
-    IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
-    IncomeTaxSessionKeys.hasCrimeBeenReportedToPolice -> "yes",
-    IncomeTaxSessionKeys.hasConfirmedDeclaration -> "true",
-    IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
-    IncomeTaxSessionKeys.penaltyNumber -> "123456789",
-    IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Submission.toString,
-    IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "no"
-  )
+  val fakeRequestForCrimeJourney: CurrentUserRequestWithAnswers[AnyContent] =
+    CurrentUserRequestWithAnswers(
+      mtdItId = testMtdItId,
+      userAnswers = UserAnswers(testJourneyId).setAnswer(HonestyDeclarationPage, true)
+    )(
+      //TODO: These will all move to be UserAnswers as part of future stories
+      FakeRequest().withSession(
+        IncomeTaxSessionKeys.reasonableExcuse -> "crime",
+        IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
+        IncomeTaxSessionKeys.hasCrimeBeenReportedToPolice -> "yes",
+        IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
+        IncomeTaxSessionKeys.penaltyNumber -> "123456789",
+        IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Submission.toString,
+        IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "no"
+      ))
 
-  val fakeRequestForCrimeJourneyMultiple: Request[AnyContent] = FakeRequest().withSession(
-    IncomeTaxSessionKeys.reasonableExcuse -> "crime",
-    IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
-    IncomeTaxSessionKeys.hasCrimeBeenReportedToPolice -> "yes",
-    IncomeTaxSessionKeys.hasConfirmedDeclaration -> "true",
-    IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
-    IncomeTaxSessionKeys.penaltyNumber -> "123456789",
-    IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Payment.toString,
-    IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "yes",
-    IncomeTaxSessionKeys.firstPenaltyChargeReference -> "123456789",
-    IncomeTaxSessionKeys.secondPenaltyChargeReference -> "123456788",
-    IncomeTaxSessionKeys.startDateOfPeriod -> "2024-01-01",
-    IncomeTaxSessionKeys.endDateOfPeriod -> "2024-01-31"
-  )
+  val fakeRequestForCrimeJourneyMultiple: CurrentUserRequestWithAnswers[AnyContent] =
+    CurrentUserRequestWithAnswers(
+      mtdItId = testMtdItId,
+      userAnswers = UserAnswers(testJourneyId).setAnswer(HonestyDeclarationPage, true)
+    )(
+      //TODO: These will all move to be UserAnswers as part of future stories
+      FakeRequest().withSession(
+        IncomeTaxSessionKeys.reasonableExcuse -> "crime",
+        IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
+        IncomeTaxSessionKeys.hasCrimeBeenReportedToPolice -> "yes",
+        IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
+        IncomeTaxSessionKeys.penaltyNumber -> "123456789",
+        IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Payment.toString,
+        IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "yes",
+        IncomeTaxSessionKeys.firstPenaltyChargeReference -> "123456789",
+        IncomeTaxSessionKeys.secondPenaltyChargeReference -> "123456788",
+        IncomeTaxSessionKeys.startDateOfPeriod -> "2024-01-01",
+        IncomeTaxSessionKeys.endDateOfPeriod -> "2024-01-31"
+      ))
 
-  val fakeRequestForOtherJourney: Request[AnyContent] = FakeRequest().withSession(
-    IncomeTaxSessionKeys.reasonableExcuse -> "other",
-    IncomeTaxSessionKeys.hasConfirmedDeclaration -> "true",
-    IncomeTaxSessionKeys.whenDidBecomeUnable -> "2022-01-01",
-    IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
-    IncomeTaxSessionKeys.whyReturnSubmittedLate -> "This is a reason.",
-    IncomeTaxSessionKeys.isUploadEvidence -> "yes",
-    IncomeTaxSessionKeys.penaltyNumber -> "123456789",
-    IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Submission.toString,
-    IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "no"
-  )
+  val fakeRequestForOtherJourney: CurrentUserRequestWithAnswers[AnyContent] =
+    CurrentUserRequestWithAnswers(
+      mtdItId = testMtdItId,
+      userAnswers = UserAnswers(testJourneyId).setAnswer(HonestyDeclarationPage, true)
+    )(
+      //TODO: These will all move to be UserAnswers as part of future stories
+      FakeRequest().withSession(
+        IncomeTaxSessionKeys.reasonableExcuse -> "other",
+        IncomeTaxSessionKeys.whenDidBecomeUnable -> "2022-01-01",
+        IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
+        IncomeTaxSessionKeys.whyReturnSubmittedLate -> "This is a reason.",
+        IncomeTaxSessionKeys.isUploadEvidence -> "yes",
+        IncomeTaxSessionKeys.penaltyNumber -> "123456789",
+        IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Submission.toString,
+        IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "no"
+      ))
 
-  val fakeRequestForOtherJourneyDeclinedUploads: Request[AnyContent] = FakeRequest().withSession(
-    IncomeTaxSessionKeys.reasonableExcuse -> "other",
-    IncomeTaxSessionKeys.hasConfirmedDeclaration -> "true",
-    IncomeTaxSessionKeys.whenDidBecomeUnable -> "2022-01-01",
-    IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
-    IncomeTaxSessionKeys.whyReturnSubmittedLate -> "This is a reason.",
-    IncomeTaxSessionKeys.isUploadEvidence -> "no",
-    IncomeTaxSessionKeys.penaltyNumber -> "123456789",
-    IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "no"
-  )
+  val fakeRequestForOtherJourneyDeclinedUploads: CurrentUserRequestWithAnswers[AnyContent] =
+    CurrentUserRequestWithAnswers(
+      mtdItId = testMtdItId,
+      userAnswers = UserAnswers(testJourneyId).setAnswer(HonestyDeclarationPage, true)
+    )(
+      //TODO: These will all move to be UserAnswers as part of future stories
+      FakeRequest().withSession(
+        IncomeTaxSessionKeys.reasonableExcuse -> "other",
+        IncomeTaxSessionKeys.whenDidBecomeUnable -> "2022-01-01",
+        IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
+        IncomeTaxSessionKeys.whyReturnSubmittedLate -> "This is a reason.",
+        IncomeTaxSessionKeys.isUploadEvidence -> "no",
+        IncomeTaxSessionKeys.penaltyNumber -> "123456789",
+        IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "no"
+      ))
 
   val appealDataAsJson: JsValue = Json.parse(
     """
@@ -412,29 +435,37 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
   }
 
   "isAppealLate" should {
-    val fakeRequestForAppealingBothPenalties: (LocalDate, LocalDate) => Request[AnyContent] = (lpp1Date: LocalDate, lpp2Date: LocalDate) =>
-      FakeRequest().withSession(
-        IncomeTaxSessionKeys.reasonableExcuse -> "crime",
-        IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "yes",
-        IncomeTaxSessionKeys.hasCrimeBeenReportedToPolice -> "yes",
-        IncomeTaxSessionKeys.hasConfirmedDeclaration -> "true",
-        IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
-        IncomeTaxSessionKeys.penaltyNumber -> "123456789",
-        IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Payment.toString,
-        IncomeTaxSessionKeys.firstPenaltyCommunicationDate -> lpp1Date.toString,
-        IncomeTaxSessionKeys.secondPenaltyCommunicationDate -> lpp2Date.toString
-      )
+    val fakeRequestForAppealingBothPenalties: (LocalDate, LocalDate) => CurrentUserRequestWithAnswers[AnyContent] = (lpp1Date: LocalDate, lpp2Date: LocalDate) =>
+      CurrentUserRequestWithAnswers(
+        mtdItId = testMtdItId,
+        userAnswers = UserAnswers(testJourneyId).setAnswer(HonestyDeclarationPage, true)
+      )(
+        //TODO: These will all move to be UserAnswers as part of future stories
+        FakeRequest().withSession(
+          IncomeTaxSessionKeys.reasonableExcuse -> "crime",
+          IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "yes",
+          IncomeTaxSessionKeys.hasCrimeBeenReportedToPolice -> "yes",
+          IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
+          IncomeTaxSessionKeys.penaltyNumber -> "123456789",
+          IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Payment.toString,
+          IncomeTaxSessionKeys.firstPenaltyCommunicationDate -> lpp1Date.toString,
+          IncomeTaxSessionKeys.secondPenaltyCommunicationDate -> lpp2Date.toString
+        ))
 
-    val fakeRequestForAppealingSinglePenalty: LocalDate => Request[AnyContent] = (date: LocalDate) =>
-      FakeRequest().withSession(
-        IncomeTaxSessionKeys.reasonableExcuse -> "crime",
-        IncomeTaxSessionKeys.dateCommunicationSent -> date.toString,
-        IncomeTaxSessionKeys.hasCrimeBeenReportedToPolice -> "yes",
-        IncomeTaxSessionKeys.hasConfirmedDeclaration -> "true",
-        IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
-        IncomeTaxSessionKeys.penaltyNumber -> "123456789",
-        IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Payment.toString
-      )
+    val fakeRequestForAppealingSinglePenalty: LocalDate => CurrentUserRequestWithAnswers[AnyContent] = (date: LocalDate) =>
+      CurrentUserRequestWithAnswers(
+        mtdItId = testMtdItId,
+        userAnswers = UserAnswers(testJourneyId).setAnswer(HonestyDeclarationPage, true)
+      )(
+        //TODO: These will all move to be UserAnswers as part of future stories
+        FakeRequest().withSession(
+          IncomeTaxSessionKeys.reasonableExcuse -> "crime",
+          IncomeTaxSessionKeys.dateCommunicationSent -> date.toString,
+          IncomeTaxSessionKeys.hasCrimeBeenReportedToPolice -> "yes",
+          IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
+          IncomeTaxSessionKeys.penaltyNumber -> "123456789",
+          IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Payment.toString
+        ))
 
     "return true" when {
       "communication date of penalty > 30 days ago" in new Setup {

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/mocks/MockSessionService.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/mocks/MockSessionService.scala
@@ -20,13 +20,13 @@ import org.mockito.ArgumentMatchers.{eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.SessionService
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.UserAnswersService
 
 import scala.concurrent.Future
 
 trait MockSessionService extends MockitoSugar {
 
-  val mockSessionService: SessionService = mock[SessionService]
+  val mockSessionService: UserAnswersService = mock[UserAnswersService]
 
   def mockGetUserAnswers(journeyId: String)(response: Future[Option[UserAnswers]]): Unit =
     when(mockSessionService.getUserAnswers(eqTo(journeyId))).thenReturn(response)

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/NotificationBadgeCountUtilSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/NotificationBadgeCountUtilSpec.scala
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.util
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.NotificationBadgeCountUtil
 
-class NotificationBadgeCountUtil extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with ScalaFutures {
+class NotificationBadgeCountUtilSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with ScalaFutures {
 
   "NotificationBadgeCountUtil" should {
 


### PR DESCRIPTION
Notes:
- I think it makes sense to create Page objects to represent the Page Key and Values to be stored. So there's a refactor here to start that transition
- It also means that `IncomeTaxSessionKeys` will be more accurately only contain the keys that we actually store in the Session Cookie
- I added some backwards compatibility to temporarily support the reasonableExcuse still being stored in the Session Cookie for now, but this can be removed once we store the value in UserAnswers.