### PR TITLE
[MIPR-1389] Added LateAppealForm and updated controller and view to render errors

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
@@ -77,4 +77,6 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
 
   lazy val mongoTTL: Duration = config.get[Duration]("mongodb.ttl")
 
+  lazy val numberOfCharsInTextArea: Int = config.get[Int]("constants.numberOfCharsInTextArea")
+
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/BaseUserAnswersController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/BaseUserAnswersController.scala
@@ -16,12 +16,14 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
+import controllers.routes
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Reads
 import play.api.mvc.Result
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.ErrorHandler
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.Page
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{Page, ReasonableExcusePage}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.IncomeTaxSessionKeys
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
@@ -39,5 +41,16 @@ trait BaseUserAnswersController extends FrontendBaseController with I18nSupport 
         logger.warn(s"[BaseUserAnswersController][withAnswer] No answer found for pageKey: ${page.key}, mtditid: ${user.mtdItId}")
         //TODO: In future, redirect to a SessionTimeout page, or JourneyExpired page that the User can recover from???
         errorHandler.internalServerErrorTemplate.map(InternalServerError(_))
+    }
+
+
+  def withReasonableExcuseAnswer(f: String => Future[Result])(implicit user: CurrentUserRequestWithAnswers[_], ec: ExecutionContext): Future[Result] =
+    //TODO: Remove this user.session code once the ReasonableExcuse page has been updated to store the answer to UserAnswers/
+    //      This is temporary backwards compatability to support the old Session based storage.
+    //      Once the ReasonableExcuse page has been updated to store the answer to UserAnswers this
+    //      must be removed!
+    user.session.get(IncomeTaxSessionKeys.reasonableExcuse) match {
+      case Some(reasonableExcuse) => f(reasonableExcuse)
+      case _ => withAnswer(ReasonableExcusePage) { f(_) }
     }
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/HonestyDeclarationController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/HonestyDeclarationController.scala
@@ -39,17 +39,8 @@ class HonestyDeclarationController @Inject()(honestyDeclaration: HonestyDeclarat
                                             )(implicit ec: ExecutionContext, val appConfig: AppConfig) extends BaseUserAnswersController {
 
   def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>
-    //TODO: Remove this user.session code once the ReasonableExcuse page has been updated to store the answer to UserAnswers/
-    //      This is temporary backwards compatability to support the old Session based storage.
-    //      Once the ReasonableExcuse page has been updated to store the answer to UserAnswers this
-    //      must be removed!
-    user.session.get(IncomeTaxSessionKeys.reasonableExcuse) match {
-      case Some(reasonableExcuse) =>
-        Future(Ok(honestyDeclaration(user.isAgent, reasonableExcuse)))
-      case _ =>
-        withAnswer(ReasonableExcusePage) { reasonableExcuse =>
-          Future(Ok(honestyDeclaration(user.isAgent, reasonableExcuse)))
-        }
+    withReasonableExcuseAnswer { reasonableExcuse =>
+      Future(Ok(honestyDeclaration(user.isAgent, reasonableExcuse)))
     }
   }
 

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/LateAppealForm.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/LateAppealForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Regexes
 
 object LateAppealForm extends Mappings {
 
-  val key = "lateAppealText"
+  val key = "delayReason"
 
   def form()(implicit appConfig: AppConfig, messages: Messages): Form[String] = Form[String](
     single(

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/LateAppealForm.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/LateAppealForm.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms
+
+import play.api.data.Form
+import play.api.data.Forms.single
+import play.api.i18n.Messages
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.mappings.Mappings
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Regexes
+
+
+object LateAppealForm extends Mappings {
+
+  val key = "lateAppealText"
+
+  def form()(implicit appConfig: AppConfig, messages: Messages): Form[String] = Form[String](
+    single(
+      key -> text(messages("lateAppeal.error.required"))
+        .verifying(
+          error = messages("lateAppeal.error.length", appConfig.numberOfCharsInTextArea),
+          constraint = _.length <= appConfig.numberOfCharsInTextArea
+        )
+        .verifying(
+          error = messages("lateAppeal.error.regex"),
+          constraint = _.matches(Regexes.textArea)
+        )
+    )
+  )
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/mappings/Formatters.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/mappings/Formatters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/mappings/Formatters.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/mappings/Formatters.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.mappings
+
+import play.api.data.FormError
+import play.api.data.format.Formatter
+
+import scala.util.control.Exception.nonFatalCatch
+
+trait Formatters {
+
+  private[mappings] def stringFormatter(message: String): Formatter[String] = new Formatter[String] {
+
+    override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], String] =
+      data.get(key) match {
+        case Some(x) if x.trim.nonEmpty =>
+          Right(x.trim)
+        case _ =>
+          Left(Seq(FormError(key, message)))
+      }
+
+    override def unbind(key: String, value: String): Map[String, String] =
+      Map(key -> value.trim)
+  }
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/mappings/Mappings.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/mappings/Mappings.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.mappings
+
+import play.api.data.{FieldMapping, Forms}
+
+trait Mappings extends Formatters {
+
+  protected def text(message: String = "error.required"): FieldMapping[String] =
+    Forms.of(stringFormatter(message))
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/Regexes.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/Regexes.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils
+
+object Regexes {
+  val textArea = "^[\u000A\u000D  ˿ -~¡-ÿĀ-ʯḀ-ỿ‐-―‘-‟₠-₿ÅK]{0,}$"
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/ErrorSummaryViewModel.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/ErrorSummaryViewModel.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels
+
+import play.api.data.Form
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.Aliases.Text
+import uk.gov.hmrc.govukfrontend.views.viewmodels.errorsummary.{ErrorLink, ErrorSummary}
+
+object ErrorSummaryViewModel {
+
+  def apply(
+             form: Form[_],
+             errorLinkOverrides: Map[String, String] = Map.empty
+           )(implicit messages: Messages): ErrorSummary = {
+
+    val errors = form.errors.map {
+      error =>
+        ErrorLink(
+          href    = Some(s"#${errorLinkOverrides.getOrElse(error.key, error.key)}"),
+          content = Text(messages(error.message, error.args: _*))
+        )
+    }
+
+    ErrorSummary(
+      errorList = errors,
+      title     = Text(messages("error.summary.title"))
+    )
+  }
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/LateAppealPage.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/LateAppealPage.scala.html
@@ -14,25 +14,31 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.ErrorSummaryViewModel
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.Layout
-@import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components._
-
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.LateAppealForm
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 
 @this(layout: Layout,
         govukButton: GovukButton,
         formHelper: FormWithCSRF,
         govukCharacterCount: GovukCharacterCount,
+        govukErrorSummary: GovukErrorSummary,
         p:P,
         h1: H1)
 
-@(isLate: Boolean, isAgent: Boolean, reasonableExcuseMessageKey: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(form: Form[_], isLate: Boolean, isAgent: Boolean, reasonableExcuseMessageKey: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @standardOrBereavement = {@if(reasonableExcuseMessageKey == "bereavementReason"){.bereavementReason} else {}}
 
-@layout(Some(titleBuilder(messages(s"lateAppeal.headingAndTitle$standardOrBereavement"))), backLinkEnabled = true) {
+@layout(Some(titleBuilder(messages(s"lateAppeal.headingAndTitle$standardOrBereavement"), Some(form))), backLinkEnabled = true) {
+
+    @if(form.errors.nonEmpty) {
+        @govukErrorSummary(ErrorSummaryViewModel(form))
+    }
 
     @formHelper(action = uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.routes.LateAppealController.submit()) {
 
@@ -41,15 +47,21 @@
         @h1(s"lateAppeal.headingAndTitle$standardOrBereavement")
         @p(s"lateAppeal.p1$standardOrBereavement", elmId = Some("infoDaysParagraph"))
 
-        @govukCharacterCount(CharacterCount(
-            id = "delayReason",
-            name = "delayReason",
-            maxLength = Some(5000),
-            label = Label(
-                content = Text(messages(s"lateAppeal.charCount$standardOrBereavement")),
-                classes = "govuk-label govuk-label--m"
-            )
-        ))
+        @{
+            govukCharacterCount(CharacterCount(
+                id = LateAppealForm.key,
+                name = LateAppealForm.key,
+                maxLength = Some(appConfig.numberOfCharsInTextArea),
+                label = Label(
+                    content = Text(messages(s"lateAppeal.charCount$standardOrBereavement")),
+                    classes = "govuk-label govuk-label--m"
+                ),
+                errorMessage = form.errors(LateAppealForm.key) match {
+                    case Nil => None
+                    case errors => Some(ErrorMessage(content = HtmlContent(errors.map(err => messages(err.message)).mkString("<br>"))))
+                },
+            ))
+        }
 
         <div class="govuk-form-group">
             @govukButton(Button(

--- a/build.sbt
+++ b/build.sbt
@@ -17,10 +17,19 @@ lazy val microservice = Project("income-tax-penalties-appeals-frontend", file(".
   .settings(Test/logBuffered := false)
   .settings(resolvers += Resolver.jcenterRepo)
   .settings(CodeCoverageSettings.settings *)
+  .settings(inConfig(Test)(testSettings): _*)
+
+lazy val testSettings: Seq[Def.Setting[_]] = Seq(
+    unmanagedSourceDirectories += baseDirectory.value / "test-fixtures",
+    Test / javaOptions += "-Dlogger.resource=logback-test.xml",
+)
 
 lazy val it = project
   .enablePlugins(PlayScala)
   .dependsOn(microservice % "test->test")
-  .settings(DefaultBuildSettings.itSettings())
+  .settings(DefaultBuildSettings.itSettings() ++ Seq(
+      unmanagedSourceDirectories := Seq(baseDirectory.value / "test-fixtures"),
+      Test / javaOptions += "-Dlogger.resource=logback-test.xml"
+  ))
   .settings(Test/logBuffered := false)
   .settings(libraryDependencies ++= AppDependencies.it)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -131,3 +131,7 @@ income-tax-penalties-appeals-frontend-host = "http://localhost:9188"
 
 feedback-frontend-host = "http://localhost:9514"
 exit-survey-origin = "ITSAPR"
+
+constants {
+  numberOfCharsInTextArea = 5000
+}

--- a/conf/messages
+++ b/conf/messages
@@ -102,6 +102,9 @@ lateAppeal.p1 = You usually need to appeal within 30 days of the date on the pen
 lateAppeal.p1.bereavementReason = You usually need to appeal within 45 days of the date on the penalty notice.
 lateAppeal.charCount = Tell us why you could not appeal within 30 days
 lateAppeal.charCount.bereavementReason = Tell us why you could not appeal within 45 days
+lateAppeal.error.required = You must provide some information about why you did not appeal sooner
+lateAppeal.error.length = Explain the reason in {0} characters or fewer
+lateAppeal.error.regex = The text must contain only letters, numbers and standard special characters
 
 # Has the crime been reported page
 # ----------------------------------------------------------

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -17,3 +17,15 @@ appeal.start.guidanceLink = Read the guidance about reasonable excuses (opens in
 appeal.start.p4 = In some cases, you''ll be asked if you want to upload evidence to support your appeal. You should gather this evidence before you continue, as you will not be able to save this appeal and complete it later. (Welsh)
 appeal.start.p5 = If you are not asked for extra evidence, this is because we don''t need any to make a decision in your particular case. (Welsh)
 appeal.start.p6 = If we decide we do need extra evidence after reviewing your appeal, we will contact you. (Welsh)
+
+# Late appeal page
+# ----------------------------------------------------------
+lateAppeal.headingAndTitle = This penalty point was issued more than 30 days ago (Welsh)
+lateAppeal.headingAndTitle.bereavementReason = This penalty point was issued more than 45 days ago (Welsh)
+lateAppeal.p1 = You usually need to appeal within 30 days of the date on the penalty notice. (Welsh)
+lateAppeal.p1.bereavementReason = You usually need to appeal within 45 days of the date on the penalty notice. (Welsh)
+lateAppeal.charCount = Tell us why you could not appeal within 30 days (Welsh)
+lateAppeal.charCount.bereavementReason = Tell us why you could not appeal within 45 days (Welsh)
+lateAppeal.error.required = You must provide some information about why you did not appeal sooner (Welsh)
+lateAppeal.error.length = Explain the reason in {0} characters or fewer (Welsh)
+lateAppeal.error.regex = The text must contain only letters, numbers and standard special characters (Welsh)

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/BtaNavLinkConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/connectors/BtaNavLinkConnectorISpec.scala
@@ -16,11 +16,11 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors
 
+import fixtures.BtaNavContentFixture
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.fixtures.BtaNavContentFixture
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.PagerDutyHelper.PagerDutyKeys
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, WiremockMethods}

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/LateAppealControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/LateAppealControllerISpec.scala
@@ -16,15 +16,24 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
+import fixtures.messages.LateAppealMessages
 import org.jsoup.Jsoup
-import play.api.http.Status.OK
+import org.mongodb.scala.Document
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
+import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.LateAppealForm
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.ReasonableExcusePage
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 class LateAppealControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+
+  lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
 
   val reasonsList: List[(String, String)] = List(
     ("bereavementReason", "45"),
@@ -37,23 +46,37 @@ class LateAppealControllerISpec extends ComponentSpecHelper with ViewSpecHelper 
     ("otherReason", "30")
   )
 
+  override def beforeEach(): Unit = {
+    userAnswersRepo.collection.deleteMany(Document()).toFuture().futureValue
+    super.beforeEach()
+  }
+
   for (reason <- reasonsList) {
+
+    val userAnswersWithReason =
+      UserAnswers(testJourneyId).setAnswer(ReasonableExcusePage, reason._1)
 
     s"GET /making-a-late-appeal with ${reason._1}" should {
 
-      testNavBar(url = "/making-a-late-appeal", reasonableExcuse = Some(reason._1))()
+      testNavBar(url = "/making-a-late-appeal") {
+        userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+      }
 
       "return an OK with a view" when {
         "the user is an authorised individual" in {
           stubAuth(OK, successfulIndividualAuthResponse)
-          val result = get("/making-a-late-appeal", reasonableExcuse = Some(reason._1))
+          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+
+          val result = get("/making-a-late-appeal")
 
           result.status shouldBe OK
         }
 
         "the user is an authorised agent" in {
           stubAuth(OK, successfulAgentAuthResponse)
-          val result = get("/making-a-late-appeal", isAgent = true, reasonableExcuse = Some(reason._1))
+          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+
+          val result = get("/making-a-late-appeal", isAgent = true)
 
           result.status shouldBe OK
         }
@@ -62,7 +85,9 @@ class LateAppealControllerISpec extends ComponentSpecHelper with ViewSpecHelper 
       "the page has the correct elements" when {
         "the user is an authorised individual" in {
           stubAuth(OK, successfulIndividualAuthResponse)
-          val result = get("/making-a-late-appeal", reasonableExcuse = Some(reason._1))
+          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+
+          val result = get("/making-a-late-appeal")
 
           val document = Jsoup.parse(result.body)
 
@@ -71,14 +96,16 @@ class LateAppealControllerISpec extends ComponentSpecHelper with ViewSpecHelper 
           document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
           document.getH1Elements.text() shouldBe s"This penalty point was issued more than ${reason._2} days ago"
           document.getElementById("infoDaysParagraph").text() shouldBe s"You usually need to appeal within ${reason._2} days of the date on the penalty notice."
-          document.getElementsByAttributeValue("for", "delayReason").text() shouldBe s"Tell us why you could not appeal within ${reason._2} days"
-          document.getElementById("delayReason-info").text() shouldBe "You can enter up to 5000 characters"
+          document.getElementsByAttributeValue("for", s"${LateAppealForm.key}").text() shouldBe s"Tell us why you could not appeal within ${reason._2} days"
+          document.getElementById(s"${LateAppealForm.key}-info").text() shouldBe "You can enter up to 5000 characters"
           document.getSubmitButton.text() shouldBe "Continue"
         }
 
         "the user is an authorised agent" in {
           stubAuth(OK, successfulAgentAuthResponse)
-          val result = get("/making-a-late-appeal", isAgent = true, reasonableExcuse = Some(reason._1))
+          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+
+          val result = get("/making-a-late-appeal", isAgent = true)
 
           val document = Jsoup.parse(result.body)
 
@@ -87,11 +114,50 @@ class LateAppealControllerISpec extends ComponentSpecHelper with ViewSpecHelper 
           document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
           document.getH1Elements.text() shouldBe s"This penalty point was issued more than ${reason._2} days ago"
           document.getElementById("infoDaysParagraph").text() shouldBe s"You usually need to appeal within ${reason._2} days of the date on the penalty notice."
-          document.getElementsByAttributeValue("for", "delayReason").text() shouldBe s"Tell us why you could not appeal within ${reason._2} days"
-          document.getElementById("delayReason-info").text() shouldBe "You can enter up to 5000 characters"
+          document.getElementsByAttributeValue("for", s"${LateAppealForm.key}").text() shouldBe s"Tell us why you could not appeal within ${reason._2} days"
+          document.getElementById(s"${LateAppealForm.key}-info").text() shouldBe "You can enter up to 5000 characters"
           document.getSubmitButton.text() shouldBe "Continue"
-
         }
+      }
+    }
+  }
+
+  "POST /making-a-late-appeal" when {
+
+    val userAnswersWithReason = UserAnswers(testJourneyId).setAnswer(ReasonableExcusePage, "bereavementReason")
+
+    "the text area content is valid" should {
+
+      "redirect to the CheckAnswers page" in {
+
+        stubAuth(OK, successfulIndividualAuthResponse)
+        userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+
+        val result = post("/making-a-late-appeal")(Map(LateAppealForm.key -> "Some reason"))
+
+        result.status shouldBe SEE_OTHER
+        result.header("Location") shouldBe Some(routes.CheckYourAnswersController.onPageLoad().url)
+      }
+    }
+
+    "the text area content is invalid" should {
+
+      "render a bad request with the Form Error on the page with a link to the field in error" in {
+
+        stubAuth(OK, successfulIndividualAuthResponse)
+        userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+
+        val result = post("/making-a-late-appeal")(Map(LateAppealForm.key -> ""))
+        result.status shouldBe BAD_REQUEST
+
+        val document = Jsoup.parse(result.body)
+
+        document.title() should include(LateAppealMessages.English.errorPrefix)
+        document.select(".govuk-error-summary__title").text() shouldBe LateAppealMessages.English.thereIsAProblem
+
+        val error1Link = document.select(".govuk-error-summary__list li:nth-of-type(1) a")
+        error1Link.text() shouldBe LateAppealMessages.English.errorRequired
+        error1Link.attr("href") shouldBe s"#${LateAppealForm.key}"
       }
     }
   }

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/NavBarTesterHelper.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/NavBarTesterHelper.scala
@@ -16,11 +16,11 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils
 
+import fixtures.BtaNavContentFixture
 import org.jsoup.Jsoup
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.http.Status.OK
 import play.api.libs.json.Json
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.fixtures.BtaNavContentFixture
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.{AuthStub, BtaNavLinksStub, MessagesStub}
 
 

--- a/test-fixtures/fixtures/BtaNavContentFixture.scala
+++ b/test-fixtures/fixtures/BtaNavContentFixture.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.fixtures
+package fixtures
 
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.btaNavBar.{NavContent, NavLink}
 

--- a/test-fixtures/fixtures/messages/LateAppealMessages.scala
+++ b/test-fixtures/fixtures/messages/LateAppealMessages.scala
@@ -16,7 +16,7 @@
 
 package fixtures.messages
 
-object MakingALateAppealMessages {
+object LateAppealMessages {
 
   sealed trait Messages { _: i18n =>
     val errorRequired: String = "You must provide some information about why you did not appeal sooner"

--- a/test-fixtures/fixtures/messages/MakingALateAppealMessages.scala
+++ b/test-fixtures/fixtures/messages/MakingALateAppealMessages.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixtures.messages
+
+object MakingALateAppealMessages {
+
+  sealed trait Messages { _: i18n =>
+    val errorRequired: String = "You must provide some information about why you did not appeal sooner"
+    val errorLength: Int => String = n => s"Explain the reason in ${"%,d".format(n)} characters or fewer"
+    val errorRegex: String = "The text must contain only letters, numbers and standard special characters"
+  }
+
+  object English extends Messages with En
+
+  object Welsh extends Messages with Cy {
+    override val errorRequired: String = "You must provide some information about why you did not appeal sooner (Welsh)"
+    override val errorLength: Int => String = n => s"Explain the reason in ${"%,d".format(n)} characters or fewer (Welsh)"
+    override val errorRegex: String = "The text must contain only letters, numbers and standard special characters (Welsh)"
+  }
+}

--- a/test-fixtures/fixtures/messages/i18n.scala
+++ b/test-fixtures/fixtures/messages/i18n.scala
@@ -24,9 +24,13 @@ sealed trait i18n {
 }
 
 trait En extends i18n {
+  val errorPrefix: String = "Error: "
+  val thereIsAProblem: String = "There is a problem"
   override val lang: Language = language.En
 }
 
 trait Cy extends i18n {
+  val errorPrefix: String = "Error: (Welsh)"
+  val thereIsAProblem: String = "Mae problem wedi codi"
   override val lang: Language = language.Cy
 }

--- a/test-fixtures/fixtures/messages/i18n.scala
+++ b/test-fixtures/fixtures/messages/i18n.scala
@@ -14,25 +14,19 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.fixtures
+package fixtures.messages
 
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.btaNavBar.{NavContent, NavLink}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language
 
-trait BtaNavContentFixture {
+sealed trait i18n {
+  val lang: Language
+}
 
-  val btaNavLink: NavLink = NavLink(
-    en = "Foo",
-    cy = "Bar",
-    url = "/url",
-    alerts = Some(0)
-  )
+trait En extends i18n {
+  override val lang: Language = language.En
+}
 
-  val btaNavContent: NavContent = NavContent(
-    home = btaNavLink,
-    account = btaNavLink,
-    messages = btaNavLink,
-    help = btaNavLink,
-    forms = btaNavLink
-  )
-
+trait Cy extends i18n {
+  override val lang: Language = language.Cy
 }

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/FormBehaviours.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/FormBehaviours.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/FormBehaviours.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/FormBehaviours.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.data.{Form, FormError}
+
+import java.time.LocalDate
+
+trait FormBehaviours extends AnyWordSpec with Matchers {
+
+  val invalidChars: String = "コし"
+
+  def mandatoryField(form: Form[_],
+                     fieldName: String,
+                     requiredError: FormError): Unit = {
+
+    s"not bind when key is not present at all for field $fieldName" in {
+
+      val result = form.bind(Map.empty[String, String]).apply(fieldName)
+      result.errors.headOption shouldBe Some(requiredError)
+    }
+
+    s"not bind blank values for field $fieldName" in {
+
+      val result = form.bind(Map(fieldName -> "")).apply(fieldName)
+      result.errors.headOption shouldBe Some(requiredError)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/LateAppealFormSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/LateAppealFormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms
 
-import fixtures.messages.MakingALateAppealMessages
+import fixtures.messages.LateAppealMessages
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -29,7 +29,7 @@ class LateAppealFormSpec extends AnyWordSpec with should.Matchers with GuiceOneA
   implicit lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
   lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
 
-  Seq(MakingALateAppealMessages.English, MakingALateAppealMessages.Welsh).foreach { messagesForLanguage =>
+  Seq(LateAppealMessages.English, LateAppealMessages.Welsh).foreach { messagesForLanguage =>
 
     s"rendering the form in '${messagesForLanguage.lang.name}'" when {
 

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/LateAppealFormSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/LateAppealFormSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms
+
+import fixtures.messages.MakingALateAppealMessages
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.data.{Form, FormError}
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+
+class LateAppealFormSpec extends AnyWordSpec with should.Matchers with GuiceOneAppPerSuite with FormBehaviours {
+
+  implicit lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+
+  Seq(MakingALateAppealMessages.English, MakingALateAppealMessages.Welsh).foreach { messagesForLanguage =>
+
+    s"rendering the form in '${messagesForLanguage.lang.name}'" when {
+
+      implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(messagesForLanguage.lang.code)))
+
+      val form: Form[String] = LateAppealForm.form()
+
+      "bind" when {
+
+        behave like mandatoryField(
+          form = form,
+          fieldName = LateAppealForm.key,
+          requiredError = FormError(LateAppealForm.key, messagesForLanguage.errorRequired)
+        )
+
+        s"allow a text value with length <= ${appConfig.numberOfCharsInTextArea}" in {
+
+          val value = "A" * appConfig.numberOfCharsInTextArea
+          val result = form.bind(Map(LateAppealForm.key -> value))
+
+          result.hasErrors shouldBe false
+          result.value shouldBe Some(value)
+        }
+
+        s"reject more than ${appConfig.numberOfCharsInTextArea} characters with correct error message" in {
+
+          val value = "A" * (appConfig.numberOfCharsInTextArea + 1)
+          val result = form.bind(Map(LateAppealForm.key -> value))
+
+          result.errors.headOption shouldBe Some(FormError(
+            key = LateAppealForm.key,
+            message = messagesForLanguage.errorLength(appConfig.numberOfCharsInTextArea)
+          ))
+        }
+
+        "reject non0standard character give regex error and not bind in" in {
+
+          val result = form.bind(Map(LateAppealForm.key -> invalidChars))
+
+          result.errors.headOption shouldBe Some(FormError(LateAppealForm.key, messagesForLanguage.errorRegex))
+        }
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/BtaNavBarServiceSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/BtaNavBarServiceSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services
 
+import fixtures.BtaNavContentFixture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -25,7 +26,6 @@ import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{Cy, En}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.mocks.MockBtaNavLinksConnector
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.fixtures.BtaNavContentFixture
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.btaNavBar.ListLink
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.NotificationBadgeCountUtil.notificationBadgeCount
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.navBar.BtaNavBar


### PR DESCRIPTION
Notes:
- Add LateAppealForm with placeholder Error Handling
- Update the Controller and View to handle the form (retrieving and storing the value on a separate subsequent sub-task)
- Add an unmanaged sources route so that test fixtures can be shared between `test` and `it/test` projects
- Update Unit and Integration Tests to test Form Errors validation and Controller form binding