### PR TITLE
[MIPR-1455] Add file-upload-journey repository and UT/IT

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/FailureDetails.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/FailureDetails.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan
+
+import play.api.libs.json.{Json, OFormat}
+
+case class FailureDetails(failureReason: FailureReasonEnum.Value,
+                          message: String)
+
+object FailureDetails {
+  implicit val format: OFormat[FailureDetails] = Json.format[FailureDetails]
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/FailureReasonEnum.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/FailureReasonEnum.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan
+
+import play.api.libs.json._
+
+import scala.util.Try
+
+object FailureReasonEnum extends Enumeration {
+  val QUARANTINE: FailureReasonEnum.Value = Value
+  val REJECTED: FailureReasonEnum.Value = Value
+  val UNKNOWN: FailureReasonEnum.Value = Value
+
+  implicit def format: Format[FailureReasonEnum.Value] = new Format[FailureReasonEnum.Value] {
+    override def writes(o: FailureReasonEnum.Value): JsValue = JsString(o.toString.toUpperCase)
+    override def reads(json: JsValue): JsResult[FailureReasonEnum.Value] =
+      Try(FailureReasonEnum.withName(json.as[String])).toOption match {
+        case Some(value) => JsSuccess(value)
+        case error => JsError(s"Invalid value '$error' for FailureReasonEnum")
+      }
+  }
+}
+

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/SuccessDetails.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/SuccessDetails.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.LocalDateTime
+
+case class SuccessDetails(fileName: String,
+                         fileMimeType: String,
+                         uploadTimestamp: LocalDateTime,
+                         checksum: String,
+                         size: Int)
+
+object SuccessDetails {
+  implicit val format: OFormat[SuccessDetails] = Json.format[SuccessDetails]
+}
+

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UploadDetails.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UploadDetails.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.LocalDateTime
+
+case class UploadDetails(fileName: String,
+                         fileMimeType: String,
+                         uploadTimestamp: LocalDateTime,
+                         checksum: String,
+                         size: Int)
+
+object UploadDetails {
+  implicit val format: OFormat[UploadDetails] = Json.format[UploadDetails]
+}
+

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UploadJourney.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UploadJourney.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan
+
+import play.api.libs.json.{Format, JsValue, Json, OWrites, Reads}
+
+import java.time.LocalDateTime
+
+case class UploadJourney(reference: String,
+                         fileStatus: UploadStatusEnum.Value,
+                         downloadUrl: Option[String] = None,
+                         uploadDetails: Option[UploadDetails] = None,
+                         failureDetails: Option[FailureDetails] = None,
+                         lastUpdated: LocalDateTime = LocalDateTime.now(),
+                         uploadFields: Option[Map[String, String]] = None)
+
+object UploadJourney {
+  val writes: OWrites[UploadJourney] = Json.format[UploadJourney]
+  val reads: Reads[UploadJourney] = (json: JsValue) => {
+    for {
+      reference <- (json \ "reference").validate[String]
+      fileStatus <- (json \ "fileStatus").validateOpt[UploadStatusEnum.Value]
+      downloadUrl <- (json \ "downloadUrl").validateOpt[String]
+      uploadDetails <- (json \ "uploadDetails").validateOpt[UploadDetails]
+      failureDetails <- (json \ "failureDetails").validateOpt[FailureDetails]
+      lastUpdated <- (json \ "lastUpdated").validateOpt[LocalDateTime]
+      uploadFields <- (json \ "uploadFields").validateOpt[Map[String, String]]
+    } yield {
+      UploadJourney(
+        reference,
+        fileStatus.getOrElse(UploadStatusEnum.WAITING),
+        downloadUrl,
+        uploadDetails,
+        failureDetails,
+        lastUpdated.fold(LocalDateTime.now)(identity),
+        uploadFields
+      )
+    }
+  }
+
+  implicit val format: Format[UploadJourney] = Format(reads, writes)
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UploadStatus.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UploadStatus.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan
+
+import play.api.libs.json.{Json, Writes}
+
+case class UploadStatus(status: String,
+                        errorMessage: Option[String] = None)
+
+object UploadStatus {
+  implicit val writes: Writes[UploadStatus] = Json.writes[UploadStatus]
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UploadStatusEnum.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UploadStatusEnum.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan
+
+import play.api.libs.json.{Format, JsError, JsResult, JsString, JsSuccess, JsValue}
+
+import scala.util.Try
+
+object UploadStatusEnum extends Enumeration {
+  val WAITING: UploadStatusEnum.Value = Value
+  val READY: UploadStatusEnum.Value = Value
+  val FAILED: UploadStatusEnum.Value = Value
+
+  implicit def format: Format[UploadStatusEnum.Value] = new Format[UploadStatusEnum.Value] {
+    override def writes(o: UploadStatusEnum.Value): JsValue = JsString(o.toString.toUpperCase)
+    override def reads(json: JsValue): JsResult[UploadStatusEnum.Value] =
+      Try(UploadStatusEnum.withName(json.as[String])).toOption match {
+        case Some(value) => JsSuccess(value)
+        case error => JsError(s"Invalid value '$error' for UploadStatusEnum")
+      }
+  }
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/FileUploadJourneyRepository.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/FileUploadJourneyRepository.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories
 
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.{UploadJourney, UploadStatus}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.{UploadJourney, UploadStatus, UploadStatusEnum}
 import uk.gov.hmrc.mongo.cache.{CacheIdType, CacheItem, DataKey, MongoCacheRepository}
 import uk.gov.hmrc.mongo.{MongoComponent, TimestampSupport}
 
@@ -58,8 +58,11 @@ class FileUploadJourneyRepository @Inject()(mongoComponent: MongoComponent,
       )
     })
 
-  def getNumberOfFiles(journeyId: String): Future[Int] =
-    findById(journeyId).map(_.fold(0)(_.data.values.size))
+  def getTotalNumberOfFiles(journeyId: String): Future[Int] =
+    getAllFiles(journeyId).map(_.size)
+
+  def getNumberOfReadyFiles(journeyId: String): Future[Int] =
+    getAllFiles(journeyId).map(_.count(_.fileStatus == UploadStatusEnum.READY))
 
   def removeFile(journeyId: String, fileReference: String): Future[Unit] =
     delete(journeyId)(DataKey(fileReference))

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/FileUploadJourneyRepository.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/FileUploadJourneyRepository.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories
+
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.{UploadJourney, UploadStatus}
+import uk.gov.hmrc.mongo.cache.{CacheIdType, CacheItem, DataKey, MongoCacheRepository}
+import uk.gov.hmrc.mongo.{MongoComponent, TimestampSupport}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class FileUploadJourneyRepository @Inject()(mongoComponent: MongoComponent,
+                                            timestampSupport: TimestampSupport,
+                                            appConfig: AppConfig)(implicit ec: ExecutionContext)
+  extends MongoCacheRepository[String](
+    mongoComponent = mongoComponent,
+    collectionName = "file-upload-journeys",
+    replaceIndexes = true,
+    ttl = appConfig.mongoTTL,
+    timestampSupport = timestampSupport,
+    cacheIdType = CacheIdType.SimpleCacheId
+  )(ec) {
+
+  def upsertFileUpload(journeyId: String, uploadJourney: UploadJourney): Future[CacheItem] =
+    put(journeyId)(DataKey(uploadJourney.reference), uploadJourney)
+
+  def getAllFiles(journeyId: String): Future[Seq[UploadJourney]] =
+    findById(journeyId).map {
+      _.fold[Seq[UploadJourney]](Seq.empty)(_.data.values.map(_.as[UploadJourney]).toSeq)
+    }
+
+  def getFile(journeyId: String, fileReference: String): Future[Option[UploadJourney]] =
+    get[UploadJourney](journeyId)(DataKey(fileReference))
+
+  def getFormFieldsForFile(journeyId: String, fileReference: String): Future[Option[Map[String, String]]] =
+    getFile(journeyId, fileReference).map(_.flatMap(_.uploadFields))
+
+  def getStatusOfFileUpload(journeyId: String, fileReference: String): Future[Option[UploadStatus]] =
+    getFile(journeyId, fileReference).map(_.map { upload =>
+      upload.failureDetails.fold(UploadStatus(upload.fileStatus.toString))(failure =>
+        UploadStatus(failure.failureReason.toString, Some(failure.message))
+      )
+    })
+
+  def getNumberOfFiles(journeyId: String): Future[Int] =
+    findById(journeyId).map(_.fold(0)(_.data.values.size))
+
+  def removeFile(journeyId: String, fileReference: String): Future[Unit] =
+    delete(journeyId)(DataKey(fileReference))
+
+  def removeAllFiles(journeyId: String): Future[Unit] =
+    deleteEntity(journeyId)
+}

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/FileUploadJourneyRepositoryISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/FileUploadJourneyRepositoryISpec.scala
@@ -91,16 +91,24 @@ class FileUploadJourneyRepositoryISpec extends ComponentSpecHelper with FileUplo
   }
 
 
-  "calling .getNumberOfFiles()" should {
+  "calling .getNumberOfReadyFiles()" should {
 
     "return 0 when there is no uploads for the journey" in {
-      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 0
+      await(repository.getNumberOfReadyFiles(testJourneyId)) shouldBe 0
     }
 
-    "return the amount of uploads" in {
-      await(repository.upsertFileUpload(testJourneyId, callbackModel))
+    "return 0 when there is no uploads that are READY for the journey" in {
+      await(repository.upsertFileUpload(testJourneyId, waitingFile))
+      await(repository.getNumberOfReadyFiles(testJourneyId)) shouldBe 0
+    }
+
+    "return a count of all READY uploads when there are some" in {
+      await(repository.upsertFileUpload(testJourneyId, waitingFile))
       await(repository.upsertFileUpload(testJourneyId, callbackModel2))
-      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 2
+      await(repository.upsertFileUpload(testJourneyId, callbackModel2.copy(reference = "ref3")))
+      await(repository.upsertFileUpload(testJourneyId, waitingFile.copy(reference = "ref4")))
+      await(repository.getTotalNumberOfFiles(testJourneyId)) shouldBe 4
+      await(repository.getNumberOfReadyFiles(testJourneyId)) shouldBe 2
     }
   }
 
@@ -110,26 +118,26 @@ class FileUploadJourneyRepositoryISpec extends ComponentSpecHelper with FileUplo
     "remove the file in the journey if it exists" in {
       await(repository.upsertFileUpload(testJourneyId, callbackModel))
       await(repository.upsertFileUpload(testJourneyId, callbackModel2))
-      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 2
+      await(repository.getTotalNumberOfFiles(testJourneyId)) shouldBe 2
       await(repository.removeFile(testJourneyId, fileRef1))
-      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 1
+      await(repository.getTotalNumberOfFiles(testJourneyId)) shouldBe 1
       await(repository.getAllFiles(testJourneyId)).headOption shouldBe Some(callbackModel2)
     }
 
     "do not remove the file in the journey if the file specified doesn't exist" in {
       await(repository.upsertFileUpload(testJourneyId, callbackModel))
       await(repository.upsertFileUpload(testJourneyId, callbackModel2))
-      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 2
+      await(repository.getTotalNumberOfFiles(testJourneyId)) shouldBe 2
       await(repository.removeFile(testJourneyId, "ref1234"))
-      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 2
+      await(repository.getTotalNumberOfFiles(testJourneyId)) shouldBe 2
     }
 
     "do not remove the file in the journey if the journey specified doesn't exist" in {
       await(repository.upsertFileUpload(testJourneyId, callbackModel))
       await(repository.upsertFileUpload(testJourneyId, callbackModel2))
-      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 2
+      await(repository.getTotalNumberOfFiles(testJourneyId)) shouldBe 2
       await(repository.removeFile("1235", fileRef1))
-      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 2
+      await(repository.getTotalNumberOfFiles(testJourneyId)) shouldBe 2
     }
   }
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/FileUploadJourneyRepositoryISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/FileUploadJourneyRepositoryISpec.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories
+
+import fixtures.FileUploadFixtures
+import play.api.test.Helpers._
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.{FailureReasonEnum, UploadStatus, UploadStatusEnum}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.ComponentSpecHelper
+
+class FileUploadJourneyRepositoryISpec extends ComponentSpecHelper with FileUploadFixtures {
+
+  lazy val repository: FileUploadJourneyRepository = injector.instanceOf[FileUploadJourneyRepository]
+
+  override def beforeEach(): Unit = {
+    await(deleteAll(repository))
+    super.beforeEach()
+  }
+
+  "calling .upsertFileUpload()" should {
+    "insert an entry when a document does not exist" in {
+      await(repository.upsertFileUpload(testJourneyId, waitingFile))
+      await(repository.getFile(testJourneyId, fileRef1)) shouldBe Some(waitingFile)
+    }
+
+    "update an entry when a document does already exist" in {
+      await(repository.upsertFileUpload(testJourneyId, waitingFile))
+      await(repository.upsertFileUpload(testJourneyId, callbackModel))
+      await(repository.getFile(testJourneyId, fileRef1)) shouldBe Some(callbackModel)
+    }
+  }
+
+
+  ".calling .getFormFieldsForFile()" should {
+
+    s"return $None when the uploadDetails does not exist" in {
+      await(repository.getFormFieldsForFile(testJourneyId, fileRef1)) shouldBe None
+    }
+
+    s"return $Some upload fields when the uploadDetails exists" in {
+      await(repository.upsertFileUpload(testJourneyId, callbackModel))
+      await(repository.getFormFieldsForFile(testJourneyId, fileRef1)) shouldBe callbackModel.uploadFields
+    }
+  }
+
+
+  "calling .getStatusOfFileUpload()" should {
+
+    s"return $None when the document is not in Mongo" in {
+      await(repository.getStatusOfFileUpload(testJourneyId, "")) shouldBe None
+    }
+
+    s"return $Some when the document is in Mongo" in {
+      await(repository.upsertFileUpload(testJourneyId, callbackModel))
+      await(repository.getStatusOfFileUpload(testJourneyId, fileRef1)) shouldBe
+        Some(UploadStatus(UploadStatusEnum.READY.toString))
+    }
+
+    s"return $Some when the document is in Mongo (failed upload)" in {
+      await(repository.upsertFileUpload(testJourneyId, callbackModelFailed))
+      await(repository.getStatusOfFileUpload(testJourneyId, fileRef1)) shouldBe
+        Some(UploadStatus(FailureReasonEnum.QUARANTINE.toString, Some(testVirusMessage)))
+    }
+  }
+
+
+  "calling .getAllFiles()" should {
+
+    s"return empty sequence when the document is not in Mongo" in {
+      await(repository.getAllFiles(testJourneyId)) shouldBe Seq()
+    }
+
+    s"return a sequence of files when files exist in Mongo" in {
+      await(repository.upsertFileUpload(testJourneyId, callbackModel))
+      await(repository.upsertFileUpload(testJourneyId, callbackModel2))
+      await(repository.getAllFiles(testJourneyId)) shouldBe Seq(callbackModel, callbackModel2)
+    }
+  }
+
+
+  "calling .getNumberOfFiles()" should {
+
+    "return 0 when there is no uploads for the journey" in {
+      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 0
+    }
+
+    "return the amount of uploads" in {
+      await(repository.upsertFileUpload(testJourneyId, callbackModel))
+      await(repository.upsertFileUpload(testJourneyId, callbackModel2))
+      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 2
+    }
+  }
+
+
+  "calling .removeFileForJourney()" should {
+
+    "remove the file in the journey if it exists" in {
+      await(repository.upsertFileUpload(testJourneyId, callbackModel))
+      await(repository.upsertFileUpload(testJourneyId, callbackModel2))
+      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 2
+      await(repository.removeFile(testJourneyId, fileRef1))
+      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 1
+      await(repository.getAllFiles(testJourneyId)).headOption shouldBe Some(callbackModel2)
+    }
+
+    "do not remove the file in the journey if the file specified doesn't exist" in {
+      await(repository.upsertFileUpload(testJourneyId, callbackModel))
+      await(repository.upsertFileUpload(testJourneyId, callbackModel2))
+      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 2
+      await(repository.removeFile(testJourneyId, "ref1234"))
+      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 2
+    }
+
+    "do not remove the file in the journey if the journey specified doesn't exist" in {
+      await(repository.upsertFileUpload(testJourneyId, callbackModel))
+      await(repository.upsertFileUpload(testJourneyId, callbackModel2))
+      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 2
+      await(repository.removeFile("1235", fileRef1))
+      await(repository.getNumberOfFiles(testJourneyId)) shouldBe 2
+    }
+  }
+
+
+  "calling .getFile()" should {
+
+    "return a upload journey model when the file reference exists" in {
+      await(repository.upsertFileUpload(testJourneyId, callbackModel))
+      await(repository.getFile(testJourneyId, fileRef1)) shouldBe Some(callbackModel)
+    }
+
+    "return nothing when the file reference does not exist" in {
+      await(repository.getFile(testJourneyId, "ref1234")) shouldBe None
+    }
+  }
+
+
+  "calling .removeAllFiles()" should {
+
+    "remove all files for the specified journey ID" in {
+      await(repository.upsertFileUpload(testJourneyId, callbackModel))
+      await(repository.upsertFileUpload(testJourneyId, callbackModel2))
+      await(repository.upsertFileUpload("12345", callbackModel))
+      await(repository.collection.countDocuments().toFuture()) shouldBe 2
+      await(repository.removeAllFiles(testJourneyId))
+      await(repository.collection.countDocuments().toFuture()) shouldBe 1
+    }
+  }
+}

--- a/test-fixtures/fixtures/FileUploadFixtures.scala
+++ b/test-fixtures/fixtures/FileUploadFixtures.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixtures
+
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.{FailureDetails, FailureReasonEnum, UploadDetails, UploadJourney, UploadStatusEnum}
+
+import java.time.LocalDateTime
+
+trait FileUploadFixtures {
+
+  val fileRef1 = "ref1"
+  val fileRef2 = "ref2"
+  val testVirusMessage = "File has a virus"
+
+  val waitingFile: UploadJourney = UploadJourney(
+    reference = fileRef1,
+    fileStatus = UploadStatusEnum.WAITING,
+    downloadUrl = None,
+    uploadDetails = None,
+    uploadFields = None
+  )
+
+  val callbackModel: UploadJourney = UploadJourney(
+    reference = fileRef1,
+    fileStatus = UploadStatusEnum.READY,
+    downloadUrl = Some("download.file/url"),
+    uploadDetails = Some(UploadDetails(
+      fileName = "file1.txt",
+      fileMimeType = "text/plain",
+      uploadTimestamp = LocalDateTime.of(2023, 1, 1, 1, 1),
+      checksum = "check1234",
+      size = 2
+    )),
+    uploadFields = Some(Map(
+      "key" -> "abcxyz",
+      "algo" -> "md5"
+    ))
+  )
+
+  val callbackModel2: UploadJourney = callbackModel.copy(
+    reference = fileRef2,
+    downloadUrl = Some("download.file2/url"),
+    uploadDetails = Some(UploadDetails(
+      fileName = "file2.txt",
+      fileMimeType = "text/plain",
+      uploadTimestamp = LocalDateTime.of(2023, 1, 1, 1, 1),
+      checksum = "check1234",
+      size = 3
+    ))
+  )
+
+  val callbackModelFailed: UploadJourney = callbackModel.copy(
+    fileStatus = UploadStatusEnum.FAILED,
+    downloadUrl = None,
+    uploadDetails = None,
+    failureDetails = Some(
+      FailureDetails(
+        failureReason = FailureReasonEnum.QUARANTINE,
+        message = testVirusMessage
+      )
+    )
+  )
+
+}

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/FailureReasonEnumSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/FailureReasonEnumSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.MessagesApi
+import play.api.libs.json.{JsString, Json}
+
+class FailureReasonEnumSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
+
+  lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+
+  "withName" should {
+    "return valid Enum value" when {
+      "string value is valid" in {
+        FailureReasonEnum.withName("QUARANTINE") shouldBe FailureReasonEnum.QUARANTINE
+        FailureReasonEnum.withName("REJECTED") shouldBe FailureReasonEnum.REJECTED
+        FailureReasonEnum.withName("UNKNOWN") shouldBe FailureReasonEnum.UNKNOWN
+      }
+    }
+    "throw NoSuchElementException" when {
+      "string is not a valid Enum value" in {
+        val error = intercept[NoSuchElementException](FailureReasonEnum.withName("foo"))
+        error.getMessage shouldBe "No value found for 'foo'"
+      }
+    }
+  }
+
+  "should serialise to JSON as expected" in {
+    Json.toJson(FailureReasonEnum.QUARANTINE) shouldBe JsString("QUARANTINE")
+    Json.toJson(FailureReasonEnum.REJECTED) shouldBe JsString("REJECTED")
+    Json.toJson(FailureReasonEnum.UNKNOWN) shouldBe JsString("UNKNOWN")
+  }
+
+  "should deserialise from JSON as expected" in {
+    JsString("QUARANTINE").as[FailureReasonEnum.Value] shouldBe FailureReasonEnum.QUARANTINE
+    JsString("REJECTED").as[FailureReasonEnum.Value] shouldBe FailureReasonEnum.REJECTED
+    JsString("UNKNOWN").as[FailureReasonEnum.Value] shouldBe FailureReasonEnum.UNKNOWN
+  }
+}

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UploadStatusEnumSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UploadStatusEnumSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.MessagesApi
+import play.api.libs.json.{JsString, Json}
+
+class UploadStatusEnumSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
+
+  lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+
+  "withName" should {
+    "return valid Enum value" when {
+      "string value is valid" in {
+        UploadStatusEnum.withName("WAITING") shouldBe UploadStatusEnum.WAITING
+        UploadStatusEnum.withName("READY") shouldBe UploadStatusEnum.READY
+        UploadStatusEnum.withName("FAILED") shouldBe UploadStatusEnum.FAILED
+      }
+    }
+    "throw NoSuchElementException" when {
+      "string is not a valid Enum value" in {
+        val error = intercept[NoSuchElementException](UploadStatusEnum.withName("foo"))
+        error.getMessage shouldBe "No value found for 'foo'"
+      }
+    }
+  }
+
+  "should serialise to JSON as expected" in {
+    Json.toJson(UploadStatusEnum.WAITING) shouldBe JsString("WAITING")
+    Json.toJson(UploadStatusEnum.READY) shouldBe JsString("READY")
+    Json.toJson(UploadStatusEnum.FAILED) shouldBe JsString("FAILED")
+  }
+
+  "should deserialise from JSON as expected" in {
+    JsString("WAITING").as[UploadStatusEnum.Value] shouldBe UploadStatusEnum.WAITING
+    JsString("READY").as[UploadStatusEnum.Value] shouldBe UploadStatusEnum.READY
+    JsString("FAILED").as[UploadStatusEnum.Value] shouldBe UploadStatusEnum.FAILED
+  }
+}


### PR DESCRIPTION
- Adds initial Upscan models that are needed
- Adds Mongo repo that uses the MongoCacheRepo with a SimpleCacheId (the `journeyId` from UserAnswers)
- Methods for Upserting, Getting, Removing have been added. The Upsert is idempotent so if no file exists it inserts a new entry otherwise it updates the existing entry. 