### PR TITLE
[MIPR-1459] Added UpscanCallbackController on internal.Route to handle the notification from upscan-notify

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/internal/UpscanCallbackController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/internal/UpscanCallbackController.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.internal
+
+import play.api.libs.json.JsValue
+import play.api.mvc.{Action, MessagesControllerComponents}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.UploadJourney
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.UpscanService
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class UpscanCallbackController @Inject()(service: UpscanService,
+                                         override val controllerComponents: MessagesControllerComponents)
+                                        (implicit ec: ExecutionContext) extends FrontendBaseController {
+
+  def callbackFromUpscan(journeyId: String): Action[JsValue] = Action.async(parse.json) { implicit request =>
+    withJsonBody[UploadJourney] { callbackModel =>
+      service.getFile(journeyId, callbackModel.reference).flatMap {
+        case Some(file) =>
+          service.upsertFileUpload(journeyId, callbackModel.copy(uploadFields = file.uploadFields)).map { _ =>
+            NoContent
+          }
+        case _ =>
+          logger.warn(s"[UpscanCallbackController][callbackFromUpscan] Callback from Upscan received for journeyId: $journeyId, fileReference: ${callbackModel.reference} that does not exist in the File Upload repository")
+          Future.successful(Gone)
+      }
+    }
+  }
+}

--- a/conf/internal.routes
+++ b/conf/internal.routes
@@ -1,0 +1,4 @@
+#Internal routes
+
++nocsrf
+POST       /upscan-callback/:journeyId             uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.internal.UpscanCallbackController.callbackFromUpscan(journeyId: String)

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -2,9 +2,6 @@
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>ERROR</level>
-        </filter>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>[%level] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
         </encoder>
@@ -14,10 +11,8 @@
     <logger name="org.asynchttpclient.netty" level="OFF"/>
     <logger name="io.netty.buffer" level="OFF"/>
     <logger name="play.core.netty" level="OFF"/>
-
-    <root level="DEBUG">
-        <!-- We send DEBUG logs to an ERROR-filtering appender rather than setting log level to ERROR directly
-        so that all the logging statements are exercised during tests -->
+    <logger name="incomeTaxPenaltiesAppealsFrontendLogger" level="DEBUG"/>
+    <root level="ERROR">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -26,7 +26,7 @@
 
     <logger name="uk.gov" level="INFO"/>
 
-    <logger name="application" level="DEBUG"/>
+    <logger name="incomeTaxPenaltiesAppealsFrontendLogger" level="DEBUG"/>
 
     <logger name="connector" level="TRACE">
         <appender-ref ref="STDOUT"/>

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,3 +1,4 @@
 # Add all the application routes to the app.routes file
+->         /internal                                  internal.Routes
 ->         /view-or-appeal-penalty/self-assessment    app.Routes
 ->         /                                          health.Routes

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/internal/UpscanCallbackControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/internal/UpscanCallbackControllerISpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.internal
+
+import fixtures.FileUploadFixtures
+import play.api.test.Helpers._
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.FileUploadJourneyRepository
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.ComponentSpecHelper
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
+
+
+class UpscanCallbackControllerISpec extends ComponentSpecHelper with FileUploadFixtures with LogCapturing {
+
+  lazy val fileUploadRepository: FileUploadJourneyRepository = app.injector.instanceOf[FileUploadJourneyRepository]
+
+  override def beforeEach(): Unit = {
+    await(fileUploadRepository.removeAllFiles(testJourneyId))
+    super.beforeEach()
+  }
+
+  "POST /internal/upscan-callback/:journeyId" when {
+
+    "a valid UploadJourney payload is received" when {
+
+      "a file for that callback reference exists within the File Upload journey" should {
+
+        "update the File Upload Journey, persisiting the values of the UploadFields. Returning a NO_CONTENT" in {
+
+          await(fileUploadRepository.upsertFileUpload(testJourneyId, waitingFile))
+
+          val result = post(s"/internal/upscan-callback/$testJourneyId")(callbackModel)
+
+          result.status shouldBe NO_CONTENT
+          await(fileUploadRepository.getFile(testJourneyId, callbackModel.reference)) shouldBe Some(callbackModel.copy(uploadFields = Some(uploadFields)))
+        }
+      }
+
+      "a file for that callback reference does NOT exist within the File Upload journey" should {
+
+        "Returning a GONE response to Upscan and log a warning message" in {
+
+          withCaptureOfLoggingFrom(logger) { logs =>
+            val result = post(s"/internal/upscan-callback/$testJourneyId")(callbackModel)
+            result.status shouldBe GONE
+
+            logs.exists(_.getMessage.contains(s"[UpscanCallbackController][callbackFromUpscan] Callback from Upscan received for journeyId: $testJourneyId, fileReference: ${callbackModel.reference} that does not exist in the File Upload repository")) shouldBe true
+          }
+        }
+      }
+    }
+  }
+}

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/ComponentSpecHelper.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/ComponentSpecHelper.scala
@@ -154,9 +154,10 @@ trait ComponentSpecHelper
 
   val baseUrl: String = "/view-or-appeal-penalty/self-assessment"
 
-  private def buildClient(path: String): WSRequest =
-    ws.url(s"http://localhost:$port$baseUrl$path").withFollowRedirects(false)
-
+  private def buildClient(path: String): WSRequest = {
+    val pathBuilder = if(path.startsWith("/internal/")) path else s"$baseUrl$path"
+    ws.url(s"http://localhost:$port$pathBuilder").withFollowRedirects(false)
+  }
 
   val cyLangCookie: WSCookie = DefaultWSCookie("PLAY_LANG", "cy")
 

--- a/test-fixtures/fixtures/FileUploadFixtures.scala
+++ b/test-fixtures/fixtures/FileUploadFixtures.scala
@@ -28,12 +28,17 @@ trait FileUploadFixtures extends BaseFixtures {
   val fileRef2 = "ref2"
   val testVirusMessage = "File has a virus"
 
+  val uploadFields = Map(
+    "key" -> "abcxyz",
+    "algo" -> "md5"
+  )
+
   val waitingFile: UploadJourney = UploadJourney(
     reference = fileRef1,
     fileStatus = UploadStatusEnum.WAITING,
     downloadUrl = None,
     uploadDetails = None,
-    uploadFields = None
+    uploadFields = Some(uploadFields)
   )
 
   val callbackModel: UploadJourney = UploadJourney(
@@ -46,10 +51,6 @@ trait FileUploadFixtures extends BaseFixtures {
       uploadTimestamp = LocalDateTime.of(2023, 1, 1, 1, 1),
       checksum = "check1234",
       size = 2
-    )),
-    uploadFields = Some(Map(
-      "key" -> "abcxyz",
-      "algo" -> "md5"
     ))
   )
 


### PR DESCRIPTION
Notes:
- #23 should be reviewed and merged prior to this, I'll then rebase this branch from `main`
- Adds internal.Routes on `/internal`
- Adds `UpscanCallbackController` to parse the response from upscan-notify and update the File Upload Journey repository if an upload entry exists for that file.