### PR TITLE
[MIPR-1467] Added NonJsFileUpload page and call upscan-initiate

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
@@ -20,7 +20,7 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.featureswitch.core.config.{
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 @Singleton
 class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesConfig) extends FeatureSwitching {
@@ -85,5 +85,8 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
 
   lazy val upscanMinFileSize: Int = config.get[Int]("upscan.minFileSize")
   lazy val upscanMaxFileSize: Int = config.get[Int]("upscan.maxFileSize")
+  lazy val upscanMaxNumberOfFiles: Int = config.get[Int]("upscan.maxNumberOfFiles")
+  lazy val upscanAcceptedMimeTypes: String = config.get[String]("upscan.acceptedMimeTypes")
+  lazy val upscanDelaySuccessRedirect: FiniteDuration = config.get[FiniteDuration]("upscan.delaySuccessRedirect")
 
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanInitiateController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanInitiateController.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.upscan
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.pattern.after
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.BaseUserAnswersController
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{AuthAction, UserAnswersAction}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan.UploadDocumentForm
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.UploadFormFields
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.UploadStatusEnum.{FAILED, READY}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.UpscanService
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.upscan.NonJsFileUploadPage
+import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.predicates.NavBarRetrievalAction
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class UpscanInitiateController @Inject()(nonJsUploadPage: NonJsFileUploadPage,
+                                         upscanService: UpscanService,
+                                         val authorised: AuthAction,
+                                         withNavBar: NavBarRetrievalAction,
+                                         withAnswers: UserAnswersAction,
+                                         actor: ActorSystem,
+                                         override val errorHandler: ErrorHandler,
+                                         override val controllerComponents: MessagesControllerComponents
+                                        )(implicit ec: ExecutionContext, appConfig: AppConfig) extends BaseUserAnswersController {
+
+  def onPageLoad(key: Option[String], errorCode: Option[String]): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>
+    val form = UploadDocumentForm.form
+    withFileUploadFormFields(key) { formFields =>
+      errorCode match {
+        case Some(code) =>
+          Future(BadRequest(nonJsUploadPage(form.withError(UploadDocumentForm.key, UploadDocumentForm.synchronousUpscanErrorMessages(code)), formFields)))
+        case _ =>
+          Future(Ok(nonJsUploadPage(form, formFields)))
+      }
+    }
+  }
+
+  private def withFileUploadFormFields(key: Option[String])(f: UploadFormFields => Future[Result])
+                                      (implicit user: CurrentUserRequestWithAnswers[_]): Future[Result] =
+    key.fold(initiateNewUpload(f)) { fileReference =>
+      logger.info(s"[UpscanInitiateController][withFileUploadFormFields] Attempting to retrieve existing form fields for fileReference: $fileReference, journeyId: ${user.journeyId}")
+      for {
+        existingFormFields <- upscanService.getFormFieldsForFile(user.journeyId, fileReference)
+        _ = if(existingFormFields.isEmpty) logger.warn(s"[UpscanInitiateController][withFileUploadFormFields] No existing form fields found for fileReference: $fileReference, journeyId: ${user.journeyId}")
+        result <- existingFormFields.fold(initiateNewUpload(f))(f)
+      } yield result
+    }
+
+  private def initiateNewUpload(f: UploadFormFields => Future[Result])
+                               (implicit user: CurrentUserRequestWithAnswers[_]): Future[Result] = {
+    logger.info(s"[UpscanInitiateController][initiateNewUpload] Initiating new file upload for journeyId: ${user.journeyId}")
+    upscanService.initiateNewFileUpload(user.journeyId).flatMap { upscanResponse =>
+      f(upscanResponse.uploadRequest)
+    }
+  }
+
+
+  def onSubmitSuccessRedirect(key: String): Action[AnyContent] = (authorised andThen withAnswers).async { implicit user =>
+    after(appConfig.upscanDelaySuccessRedirect, actor.scheduler) {
+      upscanService.getFile(user.journeyId, key).map( _.fold {
+        logger.warn(s"[UpscanInitiateController][successRedirect] Redirecting to re-initiate with error message for journeyId: ${user.journeyId}")
+        Redirect(routes.UpscanInitiateController.onPageLoad(errorCode = Some("UnableToUpload")).url)
+      } { _.fileStatus match {
+        case READY  => NotImplemented //TODO: Redirect to Success Page
+        case FAILED => NotImplemented //TODO: Redirect to Error Page
+        case _      => NotImplemented //TODO: Redirect to "It's taking longer than we expected" page
+      }})
+    }
+  }
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/upscan/UploadDocumentForm.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/upscan/UploadDocumentForm.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan
+
+import play.api.data.Form
+import play.api.data.Forms.text
+import play.api.i18n.Messages
+
+object UploadDocumentForm {
+
+  val key = "file"
+  val form: Form[String] = Form[String](key -> text)
+
+  def synchronousUpscanErrorMessages(code: String)(implicit messages: Messages): String = code match {
+    case "EntityTooSmall"  => messages("uploadEvidence.error.fileTooSmall")
+    case "EntityTooLarge"  => messages("uploadEvidence.error.fileTooLarge")
+    case "InvalidArgument" => messages("uploadEvidence.error.noFileSpecified")
+    case _                 => messages("uploadEvidence.error.unableToUpload")
+  }
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswers.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswers.scala
@@ -26,8 +26,9 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 case class CurrentUserRequestWithAnswers[A](mtdItId: String,
                                             arn: Option[String] = None,
                                             override val navBar: Option[Html] = None,
-                                            userAnswers: UserAnswers)(implicit request: Request[A]) extends WrappedRequest[A](request) with RequestWithNavBar {
+                                            userAnswers: UserAnswers)(implicit val request: Request[A]) extends WrappedRequest[A](request) with RequestWithNavBar {
   val isAgent: Boolean = arn.isDefined
+  val journeyId: String = userAnswers.journeyId
 
   def getMandatoryAnswer[A](page: Page[A])(implicit reads: Reads[A]): A =
     userAnswers.getAnswer(page) match {

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UpscanInitiateRequest.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UpscanInitiateRequest.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan
 import play.api.libs.json.{Json, Writes}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.internal.{routes => internalRoutes}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.upscan.{routes => upscanRoutes}
 
 case class UpscanInitiateRequest(callbackUrl: String,
                                  successRedirect: Option[String] = None,
@@ -32,8 +33,8 @@ object UpscanInitiateRequest {
 
   def apply(journeyId: String, appConfig: AppConfig): UpscanInitiateRequest = UpscanInitiateRequest(
     callbackUrl     = appConfig.host + internalRoutes.UpscanCallbackController.callbackFromUpscan(journeyId).url,
-    successRedirect = None, //TODO: Add when Controller created for Success Redirect
-    errorRedirect   = None, //TODO: Add when Controller created for Error Redirect
+    successRedirect = Some(appConfig.host + upscanRoutes.UpscanInitiateController.onSubmitSuccessRedirect("").url.replace("?key=", "")),
+    errorRedirect   = Some(appConfig.host + upscanRoutes.UpscanInitiateController.onPageLoad().url),
     minimumFileSize = Some(appConfig.upscanMinFileSize),
     maximumFileSize = Some(appConfig.upscanMaxFileSize)
   )

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/UserAnswersRepository.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/UserAnswersRepository.scala
@@ -22,9 +22,9 @@ import org.mongodb.scala.model.{IndexModel, IndexOptions, ReplaceOptions}
 import org.mongodb.scala.result.DeleteResult
 import play.api.libs.json.Format
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.helpers.DateTimeHelper
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.TimeMachine
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
@@ -38,7 +38,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class UserAnswersRepository @Inject()(mongo: MongoComponent,
                                       appConfig: AppConfig,
-                                      dateTimeHelper: DateTimeHelper)
+                                      timeMachine: TimeMachine)
                                      (implicit ec: ExecutionContext) extends PlayMongoRepository[UserAnswers](
   collectionName = "user-answers",
   mongoComponent = mongo,
@@ -63,7 +63,7 @@ class UserAnswersRepository @Inject()(mongo: MongoComponent,
   def getUserAnswer(id: String): Future[Option[UserAnswers]] = collection.find(equal("journeyId", id)).headOption()
 
   def upsertUserAnswer(userAnswers: UserAnswers): Future[Boolean] = {
-    val userAnswersWithUpdatedTimestamp = userAnswers.copy(lastUpdated = dateTimeHelper.dateTimeNow.toInstant(ZoneOffset.UTC))
+    val userAnswersWithUpdatedTimestamp = userAnswers.copy(lastUpdated = timeMachine.getCurrentDateTime.toInstant(ZoneOffset.UTC))
     collection.replaceOne(
         filter = equal("journeyId", userAnswers.journeyId),
         replacement = userAnswersWithUpdatedTimestamp,

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/UpscanService.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/UpscanService.scala
@@ -20,12 +20,11 @@ import play.api.libs.json.Json
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.upscan.UpscanInitiateConnector
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.{UploadFormFields, UploadJourney, UploadStatus, UploadStatusEnum, UpscanInitiateRequest, UpscanInitiateResponse}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan._
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.FileUploadJourneyRepository
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ExceptionHandlingUtil, TimeMachine}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.PagerDutyHelper.PagerDutyKeys._
-import uk.gov.hmrc.mongo.cache.CacheItem
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ExceptionHandlingUtil, TimeMachine}
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/components/Bullets.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/components/Bullets.scala.html
@@ -1,0 +1,25 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(content: Seq[Html], numberList: Boolean = false, classes: String = "govuk-list")
+
+<ul class="@classes @if(numberList){govuk-list govuk-list--number}else{govuk-list--bullet}">
+  @content.map { bullet =>
+    <li>@bullet</li>
+  }
+</ul>

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/components/Details.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/components/Details.scala.html
@@ -1,4 +1,4 @@
-/*
+@*
  * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,14 +12,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ *@
 
-package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.helpers
+@import uk.gov.hmrc.govukfrontend.views.html.components._
 
-import java.time.LocalDateTime
-import javax.inject.Inject
+@this(govukDetails: GovukDetails)
 
-class DateTimeHelper @Inject() {
+@(summary: String, content: Html)(implicit messages: Messages)
 
-  def dateTimeNow: LocalDateTime = LocalDateTime.now().truncatedTo(java.time.temporal.ChronoUnit.MILLIS)
-}
+@govukDetails(Details(summary = HtmlContent(messages(summary)), content = HtmlContent(content)))

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsFileUploadPage.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsFileUploadPage.scala.html
@@ -1,0 +1,97 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan.UploadDocumentForm
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.UploadFormFields
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.ErrorSummaryViewModel
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.{Layout, components}
+
+@this(
+        layout: Layout,
+        govukErrorSummary: GovukErrorSummary,
+        govukFileUpload: GovukFileUpload,
+        govukButton: GovukButton,
+        p: components.P,
+        h1: components.H1,
+        link: components.Link,
+        bullets: components.Bullets,
+        details: components.Details
+)
+
+@(form: Form[_], upscanFormFields: UploadFormFields)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@supportedFileTypes = {
+    @p(messages("uploadEvidence.typesOfFile.p1"))
+    @bullets(
+        Seq(
+            Html(messages("uploadEvidence.typesOfFile.li.1")),
+            Html(messages("uploadEvidence.typesOfFile.li.2")),
+            Html(messages("uploadEvidence.typesOfFile.li.3")),
+            Html(messages("uploadEvidence.typesOfFile.li.4")),
+            Html(messages("uploadEvidence.typesOfFile.li.5"))
+        )
+    )
+}
+
+@layout(pageTitle = Some(titleBuilder(messages("uploadEvidence.nonJs.headingAndTitle"), Some(form)))) {
+
+    @if(form.errors.nonEmpty) {
+        @govukErrorSummary(ErrorSummaryViewModel(form))
+    }
+
+    <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption")</span>
+    @h1("uploadEvidence.nonJs.headingAndTitle")
+
+    <p class="govuk-body">@messages("uploadEvidence.nonJs.p1")</p>
+    <p class="govuk-body">@messages("uploadEvidence.nonJs.p2")</p>
+    <p class="govuk-body">@messages("uploadEvidence.nonJs.p3", appConfig.upscanMaxNumberOfFiles)</p>
+    <p class="govuk-body">@messages("uploadEvidence.nonJs.p4", appConfig.upscanMaxFileSize)</p>
+
+    @details("uploadEvidence.typesOfFile.heading", supportedFileTypes)
+
+    <form method="POST" action="@upscanFormFields.href" id="file-upload-form" enctype="multipart/form-data">
+        @for((key, value) <- upscanFormFields.fields) {
+            <input type="hidden" name="@key" value="@value"/>
+        }
+
+        @govukFileUpload(FileUpload(
+            id = UploadDocumentForm.key,
+            name = UploadDocumentForm.key,
+            label = Label(
+                content = Text(messages(s"uploadEvidence.nonJs.label")),
+                classes = "govuk-label--m"
+            ),
+            errorMessage = form.errors(UploadDocumentForm.key) match {
+                case Nil => None
+                case errors => Some(ErrorMessage(content = HtmlContent(errors.map(err => messages(err.message)).mkString("<br>"))))
+            },
+            attributes = Map(
+                "accept" -> appConfig.upscanAcceptedMimeTypes,
+                "data-max-file-size" -> appConfig.upscanMaxFileSize.toString,
+                "data-min-file-size" -> appConfig.upscanMinFileSize.toString
+            )
+        ))
+
+        <div class="govuk-form-group">
+            @govukButton(Button(
+                content = Text(messages("common.continue"))
+            ))
+        </div>
+    </form>
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,6 +1,9 @@
 # microservice specific routes
 
 ->         /hmrc-frontend                   hmrcfrontend.Routes
+
+->         /upload-supporting-evidence      upscan.Routes
+
 GET        /logout                          uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.ServiceController.logout
 GET        /keep-alive                      uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.ServiceController.keepAlive
 GET        /assets/*file                    controllers.Assets.versioned(path = "/public", file: Asset)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -144,4 +144,7 @@ constants {
 upscan {
   minFileSize = 1
   maxFileSize = 6291456
+  maxNumberOfFiles = 5
+  acceptedMimeTypes = "image/jpeg,image/png,image/tiff,application/pdf,text/plain,application/vnd.ms-outlook,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.text,application/vnd.oasis.opendocument.spreadsheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.oasis.opendocument.presentation"
+  delaySuccessRedirect = 500millis
 }

--- a/conf/messages
+++ b/conf/messages
@@ -228,6 +228,32 @@ date.day = Day
 date.month = Month
 date.year = Year
 
+# NonJS File Upload Page
+# ----------------------------------------------------------
+uploadEvidence.nonJs.headingAndTitle = Evidence to support this appeal
+uploadEvidence.nonJs.p1 = Use this page to upload any evidence to help us review the penalty.
+uploadEvidence.nonJs.p2 = Evidence might include any documents or letters that show why the submission deadline was missed.
+uploadEvidence.nonJs.p3 = You can upload up to {0} files.
+uploadEvidence.nonJs.p4 = Each file must be smaller than 6MB.
+uploadEvidence.nonJs.label = Select a file
+
+# NonJS File Upload Page
+# ----------------------------------------------------------
+uploadEvidence.typesOfFile.heading = Types of file you can upload
+uploadEvidence.typesOfFile.p1 = These file types are allowed:
+uploadEvidence.typesOfFile.li.1 = image (.jpg, .jpeg, .png or .tiff)
+uploadEvidence.typesOfFile.li.2 = PDF (.pdf)
+uploadEvidence.typesOfFile.li.3 = email (.txt or .msg)
+uploadEvidence.typesOfFile.li.4 = Microsoft (Word, Excel or PowerPoint)
+uploadEvidence.typesOfFile.li.5 = Open Document Format (ODF)
+
+# Synchronous Upscan Error
+# ----------------------------------------------------------
+uploadEvidence.error.fileTooSmall = The selected file is empty. Choose another file.
+uploadEvidence.error.fileTooLarge = The selected file must be smaller than 6MB. Choose another file.
+uploadEvidence.error.noFileSpecified = Select a file.
+uploadEvidence.error.unableToUpload = The selected file could not be uploaded. Choose another file.
+
 crimeReason.date.error.invalid = The date of the crime must be a real date
 fireOrFloodReason.date.error.invalid = The date of the fire or flood must be a real date
 technicalReason.date.error.invalid = The date the software or technology issues began must be a real date
@@ -274,8 +300,6 @@ unexpectedHospitalReason.date.error.notInFuture = TBC
 otherReason.date.error.notInFuture = TBC
 
 common.dateHint = For example, 12 3 2018
-
-
 common.continue = Continue
 common.acceptAndContinue = Accept and continue
 common.or = or

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -72,6 +72,32 @@ date.day = Diwrnod
 date.month = Mis
 date.year = Blwyddyn
 
+# NonJS File Upload Page
+# ----------------------------------------------------------
+uploadEvidence.nonJs.headingAndTitle = Evidence to support this appeal (Welsh)
+uploadEvidence.nonJs.p1 = Use this page to upload any evidence to help us review the penalty. (Welsh)
+uploadEvidence.nonJs.p2 = Evidence might include any documents or letters that show why the submission deadline was missed. (Welsh)
+uploadEvidence.nonJs.p3 = You can upload up to {0} files. (Welsh)
+uploadEvidence.nonJs.p4 = Each file must be smaller than 6MB. (Welsh)
+uploadEvidence.nonJs.label = Select a file (Welsh)
+
+# NonJS File Upload Page
+# ----------------------------------------------------------
+uploadEvidence.typesOfFile.heading = Types of file you can upload (Welsh)
+uploadEvidence.typesOfFile.p1 = These file types are allowed: (Welsh)
+uploadEvidence.typesOfFile.li.1 = image (.jpg, .jpeg, .png or .tiff) (Welsh)
+uploadEvidence.typesOfFile.li.2 = PDF (.pdf) (Welsh)
+uploadEvidence.typesOfFile.li.3 = email (.txt or .msg) (Welsh)
+uploadEvidence.typesOfFile.li.4 = Microsoft (Word, Excel or PowerPoint) (Welsh)
+uploadEvidence.typesOfFile.li.5 = Open Document Format (ODF) (Welsh)
+
+# Synchronous Upscan Error
+# ----------------------------------------------------------
+uploadEvidence.error.fileTooSmall = Mae’r ffeil dan sylw yn wag. Dewiswch ffeil arall.
+uploadEvidence.error.fileTooLarge = Mae’n rhaid i’r ffeil dan sylw fod yn llai na 6 MB. Dewiswch ffeil arall.
+uploadEvidence.error.noFileSpecified = Dewiswch ffeil.
+uploadEvidence.error.unableToUpload = Nid oedd modd uwchlwytho’r ffeil dan sylw. Dewiswch ffeil arall.
+
 crimeReason.date.error.invalid = The date of the crime must be a real date (Welsh)
 fireOrFloodReason.date.error.invalid = The date of the fire or flood must be a real date (Welsh)
 technicalReason.date.error.invalid = The date the software or technology issues began must be a real date (Welsh)
@@ -118,6 +144,9 @@ unexpectedHospitalReason.date.error.notInFuture = TBC (Welsh)
 otherReason.date.error.notInFuture = TBC (Welsh)
 
 common.dateHint = For example, 12 3 2018 (Welsh)
+common.continue = Continue (Welsh)
+common.acceptAndContinue = Accept and continue (Welsh)
+common.or = or (Welsh)
 
 
 # Reasonable excuse

--- a/conf/upscan.routes
+++ b/conf/upscan.routes
@@ -1,0 +1,4 @@
+#File Upload routes with Upscan
+
+GET       /upload-file             uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.upscan.UpscanInitiateController.onPageLoad(key: Option[String] ?= None, errorCode: Option[String] ?= None)
+GET       /success-redirect        uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.upscan.UpscanInitiateController.onSubmitSuccessRedirect(key: String)

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationControllerISpec.scala
@@ -21,7 +21,6 @@ import play.api.http.Status.{OK, SEE_OTHER}
 import play.api.libs.json.Json
 import play.api.{Application, inject}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.helpers.DateTimeHelper
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
@@ -38,12 +37,12 @@ class InitialisationControllerISpec extends ComponentSpecHelper with ViewSpecHel
 
   val testDateTime: LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)
 
-  lazy val mockDateTime: DateTimeHelper = new DateTimeHelper {
-    override def dateTimeNow: LocalDateTime = testDateTime
+  lazy val timeMachine: TimeMachine = new TimeMachine {
+    override def getCurrentDateTime: LocalDateTime = testDateTime
   }
 
   override lazy val app: Application = appWithOverrides(
-    inject.bind[DateTimeHelper].toInstance(mockDateTime)
+    inject.bind[TimeMachine].toInstance(timeMachine)
   )
 
   "GET /initialise-appeal" should {

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanInitiateControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanInitiateControllerISpec.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.upscan
+
+import fixtures.FileUploadFixtures
+import org.jsoup.Jsoup
+import org.mongodb.scala.Document
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
+import play.api.http.Status.{BAD_REQUEST, NOT_IMPLEMENTED, OK, SEE_OTHER}
+import play.api.test.Helpers.LOCATION
+import play.api.{Application, inject}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.{FileUploadJourneyRepository, UserAnswersRepository}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.{AuthStub, UpscanStub}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, TimeMachine, ViewSpecHelper}
+import utils.TimerUtil
+
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+class UpscanInitiateControllerISpec extends ComponentSpecHelper with ViewSpecHelper with NavBarTesterHelper
+  with AuthStub
+  with UpscanStub
+  with FileUploadFixtures
+  with TimerUtil {
+
+  override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+
+  lazy val timeMachine: TimeMachine = new TimeMachine {
+    override def getCurrentDateTime: LocalDateTime = testDateTime
+  }
+
+  override lazy val app: Application = appWithOverrides(
+    inject.bind[TimeMachine].toInstance(timeMachine)
+  )
+
+  lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
+  lazy val fileUploadRepo: FileUploadJourneyRepository = app.injector.instanceOf[FileUploadJourneyRepository]
+
+  val testDateTime: LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)
+
+  override def beforeEach(): Unit = {
+    userAnswersRepo.collection.deleteMany(Document()).toFuture().futureValue
+    fileUploadRepo.collection.deleteMany(Document()).toFuture().futureValue
+    userAnswersRepo.upsertUserAnswer(UserAnswers(testJourneyId))
+    super.beforeEach()
+  }
+
+  Seq(
+    false -> successfulIndividualAuthResponse,
+    true -> successfulAgentAuthResponse
+  ).foreach { case (isAgent, authResponse) =>
+
+    s"when authenticating as an ${if (isAgent) "agent" else "individual"}" when {
+
+      s"GET /upload-supporting-evidence/upload-file" when {
+
+        "loading normal variant of the page (i.e. User is initiating the upload for the first time)" when {
+
+          "a success response is returned from the upscan-initiate call" should {
+
+            "add a new entry to File Upload repo AND render the page with the file upload meta data" in {
+              stubAuth(OK, authResponse)
+              stubUpscanInitiate(status = OK, body = initiateResponse)
+
+              val result = get("/upload-supporting-evidence/upload-file", isAgent = isAgent)
+              result.status shouldBe OK
+
+              val document = Jsoup.parse(result.body)
+              document.select("form").attr("action") shouldBe initiateResponse.uploadRequest.href
+              initiateResponse.uploadRequest.fields.map { case (key, value) =>
+                document.select(s"input[name=$key]").`val`() shouldBe value
+              }
+
+              fileUploadRepo.getFile(testJourneyId, initiateResponse.reference).futureValue shouldBe
+                Some(waitingFile.copy(lastUpdated = testDateTime))
+            }
+          }
+        }
+
+        "loading the error variant of the page (i.e. a synchronous failure has been returned when the User submitted the file to upscan)" when {
+
+          "a file upload journey exists within the File Upload repo" should {
+
+            "render a BadRequest, NOT call the initiate endpoint and should re-use the data from the File Upload repo for the hidden file meta data input" in {
+              stubAuth(OK, authResponse)
+              fileUploadRepo.upsertFileUpload(testJourneyId, waitingFile)
+
+              val result = get(s"/upload-supporting-evidence/upload-file?key=$fileRef1&errorCode=UnableToUpload", isAgent = isAgent)
+              result.status shouldBe BAD_REQUEST
+
+              val document = Jsoup.parse(result.body)
+              document.select("form").attr("action") shouldBe waitingFile.uploadFields.get.href
+              waitingFile.uploadFields.get.fields.map { case (key, value) =>
+                document.select(s"input[name=$key]").`val`() shouldBe value
+              }
+            }
+          }
+
+          "a file upload journey DOES NOT exist within the File Upload repo" should {
+
+            "render a BadRequest, call the initiate endpoint and should use the data from the initiate response for the hidden file meta data input" in {
+              stubAuth(OK, authResponse)
+              stubUpscanInitiate(status = OK, body = initiateResponse)
+
+              val result = get(s"/upload-supporting-evidence/upload-file?key=$fileRef1&errorCode=UnableToUpload", isAgent = isAgent)
+              result.status shouldBe BAD_REQUEST
+
+              val document = Jsoup.parse(result.body)
+              document.select("form").attr("action") shouldBe initiateResponse.uploadRequest.href
+              initiateResponse.uploadRequest.fields.map { case (key, value) =>
+                document.select(s"input[name=$key]").`val`() shouldBe value
+              }
+
+              fileUploadRepo.getFile(testJourneyId, initiateResponse.reference).futureValue shouldBe
+                Some(waitingFile.copy(lastUpdated = testDateTime))
+            }
+          }
+        }
+      }
+
+      s"GET /upload-supporting-evidence/success-redirect" when {
+
+        "the callback from upscan is received with a key (fileReference)" when {
+
+          "an entry for that key exists in the File Upload repo" when {
+
+            "the file status is 'READY'" should {
+
+              //TODO: Update this test in future story to test the redirect to the success page
+              "redirect to the success page after a configured artificial delay" in {
+
+                stubAuth(OK, authResponse)
+                fileUploadRepo.upsertFileUpload(testJourneyId, callbackModel)
+
+                calculateRuntime {
+                  val result = get(s"/upload-supporting-evidence/success-redirect?key=$fileRef1", isAgent = isAgent)
+                  result.status shouldBe NOT_IMPLEMENTED //TODO
+                }.shouldTakeAtLeast(appConfig.upscanDelaySuccessRedirect)
+              }
+            }
+
+            "the file status is 'WAITING'" should {
+
+              //TODO: Update this test in future story to test the redirect to the "It's taking longer than expected" page
+              "redirect to the 'Taking longer than expected' page after a configured artificial delay" in {
+                stubAuth(OK, authResponse)
+                fileUploadRepo.upsertFileUpload(testJourneyId, waitingFile)
+
+                calculateRuntime {
+                  val result = get(s"/upload-supporting-evidence/success-redirect?key=$fileRef1", isAgent = isAgent)
+                  result.status shouldBe NOT_IMPLEMENTED //TODO
+                }.shouldTakeAtLeast(appConfig.upscanDelaySuccessRedirect)
+              }
+            }
+
+            "the file status is 'FAILED'" should {
+
+              //TODO: Update this test in future story to test the redirect to the Error page
+              "redirect to the Error page after a configured artificial delay" in {
+                stubAuth(OK, authResponse)
+                fileUploadRepo.upsertFileUpload(testJourneyId, callbackModelFailed)
+
+                calculateRuntime {
+                  val result = get(s"/upload-supporting-evidence/success-redirect?key=$fileRef1", isAgent = isAgent)
+                  result.status shouldBe NOT_IMPLEMENTED //TODO
+                }.shouldTakeAtLeast(appConfig.upscanDelaySuccessRedirect)
+              }
+            }
+          }
+
+          "an entry for that key exists DOES NOT exist in the File Upload repo" should {
+
+            "redirect to the initiate upload page with the errorCode set to 'UnableToUpload'" in {
+              stubAuth(OK, authResponse)
+
+              val result = get(s"/upload-supporting-evidence/success-redirect?key=$fileRef1", isAgent = isAgent)
+              result.status shouldBe SEE_OTHER
+              result.header(LOCATION) shouldBe Some(routes.UpscanInitiateController.onPageLoad(errorCode = Some("UnableToUpload")).url)
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/stubs/UpscanStub.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/stubs/UpscanStub.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.libs.json.{JsValue, Json, Writes}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.WiremockMethods
+
+trait UpscanStub extends WiremockMethods {
+
+  def stubUpscanInitiate[T](status: Int, body: T)(implicit writes: Writes[T]): StubMapping =
+    when(POST, uri = "/upscan/v2/initiate").thenReturn(status, body)
+
+}

--- a/test-fixtures/fixtures/messages/NonJsFileUploadMessages.scala
+++ b/test-fixtures/fixtures/messages/NonJsFileUploadMessages.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixtures.messages
+
+object NonJsFileUploadMessages {
+
+  sealed trait Messages { _: i18n =>
+    val headingAndTitle = "Evidence to support this appeal"
+    val p1 = "Use this page to upload any evidence to help us review the penalty."
+    val p2 = "Evidence might include any documents or letters that show why the submission deadline was missed."
+    val p3: Int => String = n => s"You can upload up to $n files."
+    val p4 = "Each file must be smaller than 6MB."
+    val label = "Select a file"
+  }
+
+  object English extends Messages with En
+
+  object Welsh extends Messages with Cy {
+    override val headingAndTitle = "Evidence to support this appeal (Welsh)"
+    override val p1 = "Use this page to upload any evidence to help us review the penalty. (Welsh)"
+    override val p2 = "Evidence might include any documents or letters that show why the submission deadline was missed. (Welsh)"
+    override val p3: Int => String = n => s"You can upload up to $n files. (Welsh)"
+    override val p4 = "Each file must be smaller than 6MB. (Welsh)"
+    override val label = "Select a file (Welsh)"
+  }
+}

--- a/test-fixtures/fixtures/messages/SupportedFileTypeMessages.scala
+++ b/test-fixtures/fixtures/messages/SupportedFileTypeMessages.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixtures.messages
+
+object SupportedFileTypeMessages {
+
+  sealed trait Messages { _: i18n =>
+    val summaryHeading = "Types of file you can upload"
+    val p1 = "These file types are allowed:"
+    val bullet1 = "image (.jpg, .jpeg, .png or .tiff)"
+    val bullet2 = "PDF (.pdf)"
+    val bullet3 = "email (.txt or .msg)"
+    val bullet4 = "Microsoft (Word, Excel or PowerPoint)"
+    val bullet5 = "Open Document Format (ODF)"
+  }
+
+  object English extends Messages with En
+
+  object Welsh extends Messages with Cy {
+    override val summaryHeading = "Types of file you can upload (Welsh)"
+    override val p1 = "These file types are allowed: (Welsh)"
+    override val bullet1 = "image (.jpg, .jpeg, .png or .tiff) (Welsh)"
+    override val bullet2 = "PDF (.pdf) (Welsh)"
+    override val bullet3 = "email (.txt or .msg) (Welsh)"
+    override val bullet4 = "Microsoft (Word, Excel or PowerPoint) (Welsh)"
+    override val bullet5 = "Open Document Format (ODF) (Welsh)"
+  }
+}

--- a/test-fixtures/fixtures/messages/SynchronousUpscanErrorMessages.scala
+++ b/test-fixtures/fixtures/messages/SynchronousUpscanErrorMessages.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fixtures.messages
+
+object SynchronousUpscanErrorMessages {
+
+  sealed trait Messages { _: i18n =>
+    val errorFileTooSmall: String = "The selected file is empty. Choose another file."
+    val errorFileTooLarge: String = "The selected file must be smaller than 6MB. Choose another file."
+    val errorNoFileSelected: String = "Select a file."
+    val errorUploadFailed: String = "The selected file could not be uploaded. Choose another file."
+  }
+
+  object English extends Messages with En
+
+  object Welsh extends Messages with Cy {
+    override val errorFileTooSmall: String = "Mae’r ffeil dan sylw yn wag. Dewiswch ffeil arall."
+    override val errorFileTooLarge: String = "Mae’n rhaid i’r ffeil dan sylw fod yn llai na 6 MB. Dewiswch ffeil arall."
+    override val errorNoFileSelected: String = "Dewiswch ffeil."
+    override val errorUploadFailed: String = "Nid oedd modd uwchlwytho’r ffeil dan sylw. Dewiswch ffeil arall."
+  }
+}

--- a/test-fixtures/utils/TimerUtil.scala
+++ b/test-fixtures/utils/TimerUtil.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS}
+
+trait TimerUtil { _: Matchers =>
+
+  def calculateRuntime(f: => Unit): FiniteDuration = {
+    val start = System.currentTimeMillis()
+    f
+    Duration(System.currentTimeMillis() - start, MILLISECONDS)
+  }
+
+  implicit class TimerUtilOps(a: FiniteDuration) {
+    def shouldTakeAtLeast(b: FiniteDuration): Assertion =
+      if(a >= b) succeed else fail(s"$a was not greater than or equal to $b")
+  }
+}

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/UploadDocumentFormSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/UploadDocumentFormSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms
+
+import fixtures.messages.SynchronousUpscanErrorMessages
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan.UploadDocumentForm
+
+class UploadDocumentFormSpec extends AnyWordSpec with should.Matchers with GuiceOneAppPerSuite {
+
+  implicit lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+
+  Seq(SynchronousUpscanErrorMessages.English, SynchronousUpscanErrorMessages.Welsh).foreach { messagesForLanguage =>
+
+    s"rendering the form in '${messagesForLanguage.lang.name}'" when {
+
+      implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(messagesForLanguage.lang.code)))
+
+      "have the correct error message for the EntityTooSmall code" in {
+        UploadDocumentForm.synchronousUpscanErrorMessages("EntityTooSmall") shouldBe messagesForLanguage.errorFileTooSmall
+      }
+
+      "have the correct error message for the EntityTooLarge code" in {
+        UploadDocumentForm.synchronousUpscanErrorMessages("EntityTooLarge") shouldBe messagesForLanguage.errorFileTooLarge
+      }
+
+      "have the correct error message for the InvalidArgument code" in {
+        UploadDocumentForm.synchronousUpscanErrorMessages("InvalidArgument") shouldBe messagesForLanguage.errorNoFileSelected
+      }
+
+      "have the correct error message for any other code" in {
+        UploadDocumentForm.synchronousUpscanErrorMessages("UnableToUpload") shouldBe messagesForLanguage.errorUploadFailed
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UpscanInitiateRequestSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UpscanInitiateRequestSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan
+
+import fixtures.BaseFixtures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.internal.{routes => internalRoutes}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.upscan.{routes => upscanRoutes}
+
+class UpscanInitiateRequestSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with BaseFixtures {
+
+  lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+
+  "calling .apply(journeyID: String, appConfig: AppConfig)" should {
+
+    "construct a model with the correct values" in {
+
+      val actualModel = UpscanInitiateRequest(testJourneyId, appConfig)
+      val expectedModel = UpscanInitiateRequest(
+        callbackUrl     = "http://localhost:9188" + internalRoutes.UpscanCallbackController.callbackFromUpscan(testJourneyId).url,
+        successRedirect = Some("http://localhost:9188" + upscanRoutes.UpscanInitiateController.onSubmitSuccessRedirect("").url.replace("?key=", "")),
+        errorRedirect   = Some("http://localhost:9188" + upscanRoutes.UpscanInitiateController.onPageLoad().url),
+        minimumFileSize = Some(1),
+        maximumFileSize = Some(6291456)
+      )
+
+      actualModel shouldBe expectedModel
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/ViewBehaviours.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/ViewBehaviours.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.twirl.api.Html
+
+trait ViewBehaviours extends AnyWordSpec with Matchers {
+
+  trait BaseSelectors {
+    val title: String = "title"
+    val h1: String = "h1"
+    val h2: Int => String = i => s"h2:nth-of-type($i)"
+    val p: Int => String = i => s"p:nth-of-type($i)"
+    val bullet: Int => String = i => s"ul li:nth-of-type($i)"
+    val details: String = "details"
+    val detailsSummary: String = s"$details summary"
+    val label: String => String = input => s"label[for=$input]"
+    val button: String = "button.govuk-button"
+  }
+
+  def concat(selectors: String*): String = selectors.mkString(" ")
+
+  def asDocument(html: Html): Document = Jsoup.parse(html.toString())
+
+  def pageWithExpectedElementsAndMessages(checks: (String, String)*)(implicit document: Document): Unit = checks foreach {
+    case (selector, message) =>
+      s"element with selector '$selector'" should {
+        s"include the message '$message'" in {
+          val updatedSelect = if(selector == "title") selector else concat("main", selector)
+          document.select(updatedSelect) match {
+            case elements if elements.size() == 0 =>
+              fail(s"Could not find element with CSS selector: '$updatedSelect'")
+            case elements =>
+              elements.first().text() should include(message)
+          }
+        }
+      }
+  }
+}
+

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsFileUploadPageSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsFileUploadPageSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.upscan
+
+import fixtures.FileUploadFixtures
+import fixtures.messages.{NonJsFileUploadMessages, SupportedFileTypeMessages}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import play.api.mvc.Request
+import play.api.test.FakeRequest
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan.UploadDocumentForm
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewBehaviours
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.upscan.NonJsFileUploadPage
+
+class NonJsFileUploadPageSpec extends ViewBehaviours with GuiceOneAppPerSuite with FileUploadFixtures {
+
+  lazy val uploadFilePage: NonJsFileUploadPage = app.injector.instanceOf[NonJsFileUploadPage]
+  lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+
+  implicit lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit lazy val request: Request[_] = FakeRequest()
+
+  object Selectors extends BaseSelectors
+
+  Seq(
+    NonJsFileUploadMessages.English -> SupportedFileTypeMessages.English,
+    NonJsFileUploadMessages.Welsh -> SupportedFileTypeMessages.Welsh
+  ).foreach { case (messagesForLanguage, fileTypeMessages) =>
+
+    s"When rendering the File Upload page in language '${messagesForLanguage.lang.name}'" should {
+
+      implicit val messages: Messages = messagesApi.preferred(Seq(Lang(messagesForLanguage.lang.code)))
+      implicit val doc = asDocument(uploadFilePage(UploadDocumentForm.form, uploadFields))
+
+      behave like pageWithExpectedElementsAndMessages(
+        Selectors.title -> messagesForLanguage.headingAndTitle,
+        Selectors.h1 -> messagesForLanguage.headingAndTitle,
+        Selectors.p(1) -> messagesForLanguage.p1,
+        Selectors.p(2) -> messagesForLanguage.p2,
+        Selectors.p(3) -> messagesForLanguage.p3(appConfig.upscanMaxNumberOfFiles),
+        Selectors.p(4) -> messagesForLanguage.p4,
+        Selectors.detailsSummary -> fileTypeMessages.summaryHeading,
+        concat(Selectors.details, Selectors.p(1)) -> fileTypeMessages.p1,
+        concat(Selectors.details, Selectors.bullet(1)) -> fileTypeMessages.bullet1,
+        concat(Selectors.details, Selectors.bullet(2)) -> fileTypeMessages.bullet2,
+        concat(Selectors.details, Selectors.bullet(3)) -> fileTypeMessages.bullet3,
+        concat(Selectors.details, Selectors.bullet(4)) -> fileTypeMessages.bullet4,
+        concat(Selectors.details, Selectors.bullet(5)) -> fileTypeMessages.bullet5,
+        Selectors.label(UploadDocumentForm.key) -> messagesForLanguage.label,
+        Selectors.button -> messagesForLanguage.continue
+      )
+    }
+  }
+}


### PR DESCRIPTION
Notes:
- Adds the NonJsFileUpload page with content taking from the prototype
- Adds `UpscanInitiateController` which caters for rendering both the synchronous failed variant and the initiate new variant
  - on the failed state, I retrieves the file upload meta data from our Mongo repo so that we don't re-initiate a file upload with upscan (i.e. uses the same upload details)
- Added a `onSubmitSuccess` handler, which waits for a configurable artificial delay before redirecting the User to the next page
  - this is allow time for the ClamAV virus checking to be performed by Upscan and maximises our chances of a file being in a READY state when check it's state before deciding where to redirect.  
- Updated UT/IT

App-Config-PR:
- https://github.com/hmrc/app-config-base/pull/11567