### PR TITLE
[MIPR-1485] Update other controllers to retrieve ReasonableExcuse from UserAnswers and not SessionCookie

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/BaseUserAnswersController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/BaseUserAnswersController.scala
@@ -43,9 +43,6 @@ trait BaseUserAnswersController extends FrontendBaseController with I18nSupport 
         errorHandler.internalServerErrorTemplate.map(InternalServerError(_))
     }
 
-  def withReasonableExcuseAnswer(f: String => Future[Result])(implicit user: CurrentUserRequestWithAnswers[_], ec: ExecutionContext): Future[Result] =
-    withAnswer(ReasonableExcusePage)(f)
-
   def fillForm[A](form: Form[A], page: Page[A])(implicit user: CurrentUserRequestWithAnswers[_], reads: Reads[A]): Form[A] =
     user.userAnswers.getAnswer(page).fold(form)(form.fill)
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CheckYourAnswersController.scala
@@ -16,15 +16,11 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
-import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.featureswitch.core.config.FeatureSwitching
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.IncomeTaxSessionKeys
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{AuthAction, UserAnswersAction}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.ReasonableExcusePage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html._
-import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.AuthAction
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.predicates.NavBarRetrievalAction
 
 import javax.inject.Inject
@@ -34,26 +30,22 @@ import scala.concurrent.{ExecutionContext, Future}
 class CheckYourAnswersController @Inject()(checkYourAnswers: CheckYourAnswersPage,
                                            val authorised: AuthAction,
                                            withNavBar: NavBarRetrievalAction,
+                                           withAnswers: UserAnswersAction,
+                                           override val errorHandler: ErrorHandler,
                                            override val controllerComponents: MessagesControllerComponents,
                                           )(implicit ec: ExecutionContext,
-                                            val appConfig: AppConfig) extends FrontendBaseController with I18nSupport with FeatureSwitching {
-  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar) { implicit currentUser =>
-        val optReasonableExcuse = currentUser.session.get(IncomeTaxSessionKeys.reasonableExcuse)
+                                            val appConfig: AppConfig) extends BaseUserAnswersController {
 
-        optReasonableExcuse match {
-          case Some(reasonableExcuse) =>
-            Ok(checkYourAnswers(
-              true, currentUser.isAgent, reasonableExcuse
-            ))
-          case _ =>
-            Redirect(routes.ReasonableExcuseController.onPageLoad())
-        }
+  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit currentUser =>
+    withAnswer(ReasonableExcusePage) { reasonableExcuse =>
+      Future(Ok(checkYourAnswers(
+        true, currentUser.isAgent, reasonableExcuse
+      )))
+    }
   }
 
-
   def submit(): Action[AnyContent] = authorised { _ =>
-
-        Redirect(routes.ConfirmationController.onPageLoad())
+    Redirect(routes.ConfirmationController.onPageLoad())
   }
 
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ConfirmationController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ConfirmationController.scala
@@ -16,15 +16,11 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
-import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.featureswitch.core.config.FeatureSwitching
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.IncomeTaxSessionKeys
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{AuthAction, UserAnswersAction}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.ReasonableExcusePage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html._
-import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.AuthAction
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.predicates.NavBarRetrievalAction
 
 import javax.inject.Inject
@@ -34,20 +30,17 @@ import scala.concurrent.{ExecutionContext, Future}
 class ConfirmationController @Inject()(confirmationPage: ConfirmationPage,
                                        val authorised: AuthAction,
                                        withNavBar: NavBarRetrievalAction,
+                                       withAnswers: UserAnswersAction,
+                                       override val errorHandler: ErrorHandler,
                                        override val controllerComponents: MessagesControllerComponents
                                       )(implicit ec: ExecutionContext,
-                                        val appConfig: AppConfig) extends FrontendBaseController with I18nSupport with FeatureSwitching {
-  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar) { implicit currentUser =>
-        val optReasonableExcuse = currentUser.session.get(IncomeTaxSessionKeys.reasonableExcuse)
+                                        val appConfig: AppConfig) extends BaseUserAnswersController {
 
-        optReasonableExcuse match {
-          case Some(reasonableExcuse) =>
-            Ok(confirmationPage(
-              true, currentUser.isAgent, reasonableExcuse
-            ))
-          case _ =>
-            Redirect(routes.ReasonableExcuseController.onPageLoad())
-        }
+  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit currentUser =>
+    withAnswer(ReasonableExcusePage) { reasonableExcuse =>
+      Future(Ok(confirmationPage(
+        true, currentUser.isAgent, reasonableExcuse
+      )))
+    }
   }
-
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CrimeReportedController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CrimeReportedController.scala
@@ -20,7 +20,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{AuthAction, UserAnswersAction}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.CrimeReportedForm
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.CrimeReportedPage
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{CrimeReportedPage, ReasonableExcusePage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.UserAnswersService
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html._
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.predicates.NavBarRetrievalAction
@@ -39,7 +39,7 @@ class CrimeReportedController @Inject()(hasTheCrimeBeenReportedPage: HasTheCrime
                                        )(implicit ec: ExecutionContext, val appConfig: AppConfig) extends BaseUserAnswersController {
 
   def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit currentUser =>
-    withReasonableExcuseAnswer { reasonableExcuse =>
+    withAnswer(ReasonableExcusePage) { reasonableExcuse =>
       Future(Ok(hasTheCrimeBeenReportedPage(
         form = fillForm(CrimeReportedForm.form, CrimeReportedPage),
         isLate = true,
@@ -52,7 +52,7 @@ class CrimeReportedController @Inject()(hasTheCrimeBeenReportedPage: HasTheCrime
   def submit(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>
     CrimeReportedForm.form.bindFromRequest().fold(
       formWithErrors =>
-        withReasonableExcuseAnswer { reasonableExcuse =>
+        withAnswer(ReasonableExcusePage) { reasonableExcuse =>
           Future(BadRequest(hasTheCrimeBeenReportedPage(
             form = formWithErrors,
             isLate = true,

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/HonestyDeclarationController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/HonestyDeclarationController.scala
@@ -39,7 +39,7 @@ class HonestyDeclarationController @Inject()(honestyDeclaration: HonestyDeclarat
                                             )(implicit ec: ExecutionContext, val appConfig: AppConfig) extends BaseUserAnswersController {
 
   def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>
-    withReasonableExcuseAnswer { reasonableExcuse =>
+    withAnswer(ReasonableExcusePage) { reasonableExcuse =>
       Future(Ok(honestyDeclaration(user.isAgent, reasonableExcuse)))
     }
   }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/LateAppealController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/LateAppealController.scala
@@ -20,7 +20,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{AuthAction, UserAnswersAction}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.LateAppealForm
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.LateAppealPage
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{LateAppealPage, ReasonableExcusePage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.UserAnswersService
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.LateAppealPage
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.predicates.NavBarRetrievalAction
@@ -39,7 +39,7 @@ class LateAppealController @Inject()(lateAppeal: LateAppealPage,
                                     )(implicit ec: ExecutionContext, val appConfig: AppConfig) extends BaseUserAnswersController {
 
   def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>
-    withReasonableExcuseAnswer { reasonableExcuse =>
+    withAnswer(ReasonableExcusePage) { reasonableExcuse =>
       Future(Ok(lateAppeal(
         form = fillForm(LateAppealForm.form(), LateAppealPage),
         isLate = true,
@@ -52,7 +52,7 @@ class LateAppealController @Inject()(lateAppeal: LateAppealPage,
   def submit(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>
     LateAppealForm.form().bindFromRequest().fold(
       formWithErrors =>
-        withReasonableExcuseAnswer { reasonableExcuse =>
+        withAnswer(ReasonableExcusePage) { reasonableExcuse =>
           Future(BadRequest(lateAppeal(formWithErrors, isLate = true, isAgent = user.isAgent, reasonableExcuse)))
         },
       lateAppealReason => {

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ViewAppealDetailsController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ViewAppealDetailsController.scala
@@ -16,15 +16,11 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
-import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.featureswitch.core.config.FeatureSwitching
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.IncomeTaxSessionKeys
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{AuthAction, UserAnswersAction}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.ReasonableExcusePage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html._
-import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.AuthAction
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.predicates.NavBarRetrievalAction
 
 import javax.inject.Inject
@@ -34,20 +30,16 @@ import scala.concurrent.{ExecutionContext, Future}
 class ViewAppealDetailsController @Inject()(viewAppealDetailsPage: ViewAppealDetailsPage,
                                             val authorised: AuthAction,
                                             withNavBar: NavBarRetrievalAction,
+                                            withAnswers: UserAnswersAction,
+                                            override val errorHandler: ErrorHandler,
                                             override val controllerComponents: MessagesControllerComponents,
-                                            )(implicit ec: ExecutionContext,
-                                              val appConfig: AppConfig) extends FrontendBaseController with I18nSupport with FeatureSwitching {
-  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar)  { implicit currentUser =>
-        val optReasonableExcuse = currentUser.session.get(IncomeTaxSessionKeys.reasonableExcuse)
+                                           )(implicit ec: ExecutionContext, val appConfig: AppConfig) extends BaseUserAnswersController {
 
-        optReasonableExcuse match {
-          case Some(reasonableExcuse) =>
-            Ok(viewAppealDetailsPage(
-              true, currentUser.isAgent, reasonableExcuse
-            ))
-          case _ =>
-            Redirect(routes.ReasonableExcuseController.onPageLoad())
-        }
+  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit currentUser =>
+    withAnswer(ReasonableExcusePage) { reasonableExcuse =>
+      Future(Ok(viewAppealDetailsPage(
+        true, currentUser.isAgent, reasonableExcuse
+      )))
+    }
   }
-
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenController.scala
@@ -42,8 +42,7 @@ class WhenDidEventHappenController @Inject()(whenDidEventHappenView: WhenDidEven
 
 
   def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>
-
-    withReasonableExcuseAnswer { reasonableExcuse =>
+    withAnswer(ReasonableExcusePage) { reasonableExcuse =>
       Future(Ok(whenDidEventHappenView(
         form = fillForm(WhenDidEventHappenForm.form(reasonableExcuse), WhenDidEventHappenPage),
         isAgent = user.isAgent,
@@ -53,9 +52,7 @@ class WhenDidEventHappenController @Inject()(whenDidEventHappenView: WhenDidEven
   }
 
   def submit(): Action[AnyContent] = (authorised andThen withAnswers).async { implicit user =>
-
-
-    withReasonableExcuseAnswer { reasonableExcuse =>
+    withAnswer(ReasonableExcusePage) { reasonableExcuse =>
       WhenDidEventHappenForm.form(reasonableExcuse).bindFromRequest().fold(
         formWithErrors =>
           Future.successful(BadRequest(whenDidEventHappenView(
@@ -80,5 +77,4 @@ class WhenDidEventHappenController @Inject()(whenDidEventHappenView: WhenDidEven
         })
     }
   }
-
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/IncomeTaxSessionKeys.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/IncomeTaxSessionKeys.scala
@@ -28,7 +28,6 @@ object IncomeTaxSessionKeys {
   val vatAmount = "vatAmount"
   val principalChargeReference = "principalChargeReference"
   val isCaLpp = "isCaLpp"
-  val reasonableExcuse = "reasonableExcuse"
   val dateOfCrime = "dateOfCrime"
   val dateOfFireOrFlood = "dateOfFireOrFlood"
   val whenPersonLeftTheBusiness = "whenPersonLeftTheBusiness"
@@ -76,7 +75,6 @@ object IncomeTaxSessionKeys {
     endDateOfPeriod,
     dueDateOfPeriod,
     penaltyNumber,
-    reasonableExcuse,
     dateOfCrime,
     dateOfFireOrFlood,
     dateCommunicationSent,

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CheckYourAnswersControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CheckYourAnswersControllerISpec.scala
@@ -17,14 +17,21 @@
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
 import org.jsoup.Jsoup
+import org.mongodb.scala.Document
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.OK
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.ReasonableExcusePage
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 class CheckYourAnswersControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+
+  lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
 
   val bereavementReasonMessage: String = "When did the person die?"
   val cessationReasonMessage: String = "TBC cessationReason"
@@ -55,24 +62,36 @@ class CheckYourAnswersControllerISpec extends ComponentSpecHelper with ViewSpecH
     ("otherReason", otherReasonValue, otherReasonMessage)
   )
 
+  override def beforeEach(): Unit = {
+    deleteAll(userAnswersRepo)
+    super.beforeEach()
+  }
 
   for (reason <- reasonsList) {
 
+    val userAnswersWithReason = UserAnswers(testJourneyId).setAnswer(ReasonableExcusePage, reason._1)
+
     s"GET /check-your-answers with ${reason._1}" should {
 
-      testNavBar(url = "/check-your-answers", reasonableExcuse = Some(reason._1))()
+      testNavBar(url = "/check-your-answers")(
+        userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+      )
 
       "return an OK with a view" when {
         "the user is an authorised individual" in {
           stubAuth(OK, successfulIndividualAuthResponse)
-          val result = get("/check-your-answers", reasonableExcuse = Some(reason._1))
+          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+
+          val result = get("/check-your-answers")
 
           result.status shouldBe OK
         }
 
         "the user is an authorised agent" in {
           stubAuth(OK, successfulAgentAuthResponse)
-          val result = get("/check-your-answers", isAgent = true, reasonableExcuse = Some(reason._1))
+          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+
+          val result = get("/check-your-answers", isAgent = true)
 
           result.status shouldBe OK
         }
@@ -81,7 +100,9 @@ class CheckYourAnswersControllerISpec extends ComponentSpecHelper with ViewSpecH
       "the page has the correct elements" when {
         "the user is an authorised individual" in {
           stubAuth(OK, successfulIndividualAuthResponse)
-          val result = get("/check-your-answers", reasonableExcuse = Some(reason._1))
+          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+
+          val result = get("/check-your-answers")
 
           val document = Jsoup.parse(result.body)
 
@@ -113,7 +134,9 @@ class CheckYourAnswersControllerISpec extends ComponentSpecHelper with ViewSpecH
 
         "the user is an authorised agent" in {
           stubAuth(OK, successfulAgentAuthResponse)
-          val result = get("/check-your-answers", isAgent = true, reasonableExcuse = Some(reason._1))
+          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+
+          val result = get("/check-your-answers", isAgent = true)
 
           val document = Jsoup.parse(result.body)
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ReasonableExcuseControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ReasonableExcuseControllerISpec.scala
@@ -27,14 +27,12 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.ReasonableExcusePage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.IncomeTaxSessionKeys.reasonableExcuse
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 
 class ReasonableExcuseControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
-
 
   lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenControllerISpec.scala
@@ -81,7 +81,7 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
           userAnswersRepo.upsertUserAnswer(userAnswersWithReason.setAnswer(WhenDidEventHappenPage, LocalDate.of(2024, 4, 2))).futureValue
 
-          val result = get("/when-did-the-event-happen", reasonableExcuse = Some(reason._1))
+          val result = get("/when-did-the-event-happen")
 
           result.status shouldBe OK
           val document = Jsoup.parse(result.body)
@@ -94,7 +94,7 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
           stubAuth(OK, successfulAgentAuthResponse)
           userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
 
-          val result = get("/when-did-the-event-happen", isAgent = true, reasonableExcuse = Some(reason._1))
+          val result = get("/when-did-the-event-happen", isAgent = true)
 
           result.status shouldBe OK
 
@@ -110,7 +110,7 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
           stubAuth(OK, successfulIndividualAuthResponse)
           userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
 
-          val result = get("/when-did-the-event-happen", reasonableExcuse = Some(reason._1))
+          val result = get("/when-did-the-event-happen")
 
           val document = Jsoup.parse(result.body)
 
@@ -129,7 +129,7 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
           stubAuth(OK, successfulAgentAuthResponse)
           userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
 
-          val result = get("/when-did-the-event-happen", isAgent = true, reasonableExcuse = Some(reason._1))
+          val result = get("/when-did-the-event-happen", isAgent = true)
 
           val document = Jsoup.parse(result.body)
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/FileUploadJourneyRepositoryISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/FileUploadJourneyRepositoryISpec.scala
@@ -25,7 +25,7 @@ class FileUploadJourneyRepositoryISpec extends ComponentSpecHelper with FileUplo
   lazy val repository: FileUploadJourneyRepository = injector.instanceOf[FileUploadJourneyRepository]
 
   override def beforeEach(): Unit = {
-    await(deleteAll(repository))
+    deleteAll(repository)
     super.beforeEach()
   }
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/UserAnswersRepositoryISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/repositories/UserAnswersRepositoryISpec.scala
@@ -26,7 +26,7 @@ class UserAnswersRepositoryISpec extends ComponentSpecHelper {
   lazy val repository: UserAnswersRepository = injector.instanceOf[UserAnswersRepository]
 
   class Setup {
-    await(deleteAll(repository))
+    deleteAll(repository)
   }
 
   val userAnswers: UserAnswers = UserAnswers(journeyId = "journey123", data = Json.obj("key1" -> "value1", "key2" -> "value2"))

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/NavBarTesterHelper.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/NavBarTesterHelper.scala
@@ -26,14 +26,14 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.{AuthStub, BtaNavLink
 
 trait NavBarTesterHelper extends AnyWordSpec with BtaNavLinksStub with MessagesStub with BtaNavContentFixture { _: ComponentSpecHelper with AuthStub =>
 
-  def testNavBar(url: String, queryParams: Map[String, String] = Map.empty, reasonableExcuse: Option[String] = None)(runStubsAndUserAnswersSetup: => Unit = ()): Unit = {
+  def testNavBar(url: String, queryParams: Map[String, String] = Map.empty)(runStubsAndUserAnswersSetup: => Unit = ()): Unit = {
     "Checking the Navigation Bar" when {
       "the origin is PTA" should {
         "render the PTA content" in {
           stubAuth(OK, successfulIndividualAuthResponse)
           stubMessagesCount()(OK, Json.obj("count" -> 0))
           runStubsAndUserAnswersSetup
-          val result = get(url, origin = Some("PTA"), queryParams = queryParams, reasonableExcuse = reasonableExcuse)
+          val result = get(url, origin = Some("PTA"), queryParams = queryParams)
 
           result.status shouldBe OK
           val document = Jsoup.parse(result.body)
@@ -47,7 +47,7 @@ trait NavBarTesterHelper extends AnyWordSpec with BtaNavLinksStub with MessagesS
           stubAuth(OK, successfulIndividualAuthResponse)
           runStubsAndUserAnswersSetup
           stubBtaNavLinks()(OK, Json.toJson(btaNavContent))
-          val result = get(url, origin = Some("BTA"), queryParams = queryParams, reasonableExcuse = reasonableExcuse)
+          val result = get(url, origin = Some("BTA"), queryParams = queryParams)
 
           result.status shouldBe OK
           val document = Jsoup.parse(result.body)
@@ -60,7 +60,7 @@ trait NavBarTesterHelper extends AnyWordSpec with BtaNavLinksStub with MessagesS
         "render without a Nav" in {
           stubAuth(OK, successfulIndividualAuthResponse)
           runStubsAndUserAnswersSetup
-          val result = get(url, origin = None, queryParams = queryParams, reasonableExcuse = reasonableExcuse)
+          val result = get(url, origin = None, queryParams = queryParams)
 
           result.status shouldBe OK
           val document = Jsoup.parse(result.body)
@@ -74,7 +74,7 @@ trait NavBarTesterHelper extends AnyWordSpec with BtaNavLinksStub with MessagesS
         "render without a Nav" in {
           stubAuth(OK, successfulAgentAuthResponse)
           runStubsAndUserAnswersSetup
-          val result = get(url, isAgent = true, origin = None, queryParams = queryParams, reasonableExcuse = reasonableExcuse)
+          val result = get(url, isAgent = true, origin = None, queryParams = queryParams)
 
           result.status shouldBe OK
           val document = Jsoup.parse(result.body)

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealServiceSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealServiceSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.{JsValue, Json}
-import play.api.mvc.{AnyContent, Request}
+import play.api.mvc.AnyContent
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
@@ -33,8 +33,8 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.PenaltiesConnect
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.httpParsers.{InvalidJson, UnexpectedFailure}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.{AppealSubmissionResponseModel, MultiplePenaltiesData}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{AppealData, CrimeReportedEnum, CurrentUserRequestWithAnswers, PenaltyTypeEnum, ReasonableExcuse}
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{CrimeReportedPage, HonestyDeclarationPage}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models._
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{CrimeReportedPage, HonestyDeclarationPage, ReasonableExcusePage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{IncomeTaxSessionKeys, TimeMachine, UUIDGenerator}
 import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
@@ -61,10 +61,10 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
       userAnswers = UserAnswers(testJourneyId)
         .setAnswer(HonestyDeclarationPage, true)
         .setAnswer(CrimeReportedPage, CrimeReportedEnum.yes)
+        .setAnswer(ReasonableExcusePage, "crime")
     )(
       //TODO: These will all move to be UserAnswers as part of future stories
       FakeRequest().withSession(
-        IncomeTaxSessionKeys.reasonableExcuse -> "crime",
         IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
         IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
         IncomeTaxSessionKeys.penaltyNumber -> "123456789",
@@ -78,10 +78,10 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
       userAnswers = UserAnswers(testJourneyId)
         .setAnswer(HonestyDeclarationPage, true)
         .setAnswer(CrimeReportedPage, CrimeReportedEnum.yes)
+        .setAnswer(ReasonableExcusePage, "crime")
     )(
       //TODO: These will all move to be UserAnswers as part of future stories
       FakeRequest().withSession(
-        IncomeTaxSessionKeys.reasonableExcuse -> "crime",
         IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
         IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
         IncomeTaxSessionKeys.penaltyNumber -> "123456789",
@@ -96,11 +96,12 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
   val fakeRequestForOtherJourney: CurrentUserRequestWithAnswers[AnyContent] =
     CurrentUserRequestWithAnswers(
       mtdItId = testMtdItId,
-      userAnswers = UserAnswers(testJourneyId).setAnswer(HonestyDeclarationPage, true)
+      userAnswers = UserAnswers(testJourneyId)
+        .setAnswer(HonestyDeclarationPage, true)
+        .setAnswer(ReasonableExcusePage, "other")
     )(
       //TODO: These will all move to be UserAnswers as part of future stories
       FakeRequest().withSession(
-        IncomeTaxSessionKeys.reasonableExcuse -> "other",
         IncomeTaxSessionKeys.whenDidBecomeUnable -> "2022-01-01",
         IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
         IncomeTaxSessionKeys.whyReturnSubmittedLate -> "This is a reason.",
@@ -113,11 +114,12 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
   val fakeRequestForOtherJourneyDeclinedUploads: CurrentUserRequestWithAnswers[AnyContent] =
     CurrentUserRequestWithAnswers(
       mtdItId = testMtdItId,
-      userAnswers = UserAnswers(testJourneyId).setAnswer(HonestyDeclarationPage, true)
+      userAnswers = UserAnswers(testJourneyId)
+        .setAnswer(HonestyDeclarationPage, true)
+        .setAnswer(ReasonableExcusePage, "other")
     )(
       //TODO: These will all move to be UserAnswers as part of future stories
       FakeRequest().withSession(
-        IncomeTaxSessionKeys.reasonableExcuse -> "other",
         IncomeTaxSessionKeys.whenDidBecomeUnable -> "2022-01-01",
         IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
         IncomeTaxSessionKeys.whyReturnSubmittedLate -> "This is a reason.",
@@ -443,10 +445,10 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
         userAnswers = UserAnswers(testJourneyId)
           .setAnswer(HonestyDeclarationPage, true)
           .setAnswer(CrimeReportedPage, CrimeReportedEnum.yes)
+          .setAnswer(ReasonableExcusePage, "crime")
       )(
         //TODO: These will all move to be UserAnswers as part of future stories
         FakeRequest().withSession(
-          IncomeTaxSessionKeys.reasonableExcuse -> "crime",
           IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "yes",
           IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
           IncomeTaxSessionKeys.penaltyNumber -> "123456789",
@@ -461,10 +463,10 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
         userAnswers = UserAnswers(testJourneyId)
           .setAnswer(HonestyDeclarationPage, true)
           .setAnswer(CrimeReportedPage, CrimeReportedEnum.yes)
+          .setAnswer(ReasonableExcusePage, "crime")
       )(
         //TODO: These will all move to be UserAnswers as part of future stories
         FakeRequest().withSession(
-          IncomeTaxSessionKeys.reasonableExcuse -> "crime",
           IncomeTaxSessionKeys.dateCommunicationSent -> date.toString,
           IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
           IncomeTaxSessionKeys.penaltyNumber -> "123456789",


### PR DESCRIPTION
Notes:
- this should fix the pipeline, ran `main` JTs against this branch and they pass 🟢 