### PR TITLE
[MIPR-1405] Update Appeal Submission model to retrieve from UserAnswers

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/appeals/AppealSubmission.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/appeals/AppealSubmission.scala
@@ -19,11 +19,12 @@ package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals
 import play.api.libs.json._
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models._
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.submission._
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.UploadJourney
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages._
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.IncomeTaxSessionKeys
 
+import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
-import java.time.{LocalDate, LocalDateTime}
 
 case class AppealSubmission(
                              sourceSystem: String,
@@ -56,7 +57,8 @@ object AppealSubmission {
   //scalastyle:off
   def constructModelBasedOnReasonableExcuse(reasonableExcuse: String,
                                             isLateAppeal: Boolean,
-                                            agentReferenceNo: Option[String], //                                            uploadedFiles: Option[Seq[UploadJourney]],
+                                            agentReferenceNo: Option[String],
+                                            uploadedFiles: Option[Seq[UploadJourney]],
                                             mtdItId: String)
                                            (implicit request: CurrentUserRequestWithAnswers[_]): AppealSubmission = {
     val isLPP: Boolean = !request.session.get(IncomeTaxSessionKeys.appealType).contains(PenaltyTypeEnum.Late_Submission.toString)
@@ -69,7 +71,7 @@ object AppealSubmission {
     def baseAppealSubmission(appealInfo: AppealInformation) = AppealSubmission(
       sourceSystem = "MDTP",
       taxRegime = "ITSA",
-      customerReferenceNo = s"MTDITID${mtdItId}",
+      customerReferenceNo = s"MTDITID$mtdItId",
       dateOfAppeal = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS),
       isLPP = isLPP,
       appealSubmittedBy = if (agentReferenceNo.isDefined) "agent" else "customer",
@@ -82,102 +84,95 @@ object AppealSubmission {
         baseAppealSubmission(BereavementAppealInformation(
           reasonableExcuse = reasonableExcuse,
           honestyDeclaration = request.getMandatoryAnswer(HonestyDeclarationPage),
-          startDateOfEvent = request.session.get(IncomeTaxSessionKeys.whenDidThePersonDie).map(LocalDate.parse).get.atStartOfDay(),
+          startDateOfEvent = request.getMandatoryAnswer(WhenDidEventHappenPage).atStartOfDay(),
           statement = None,
           lateAppeal = isLateAppeal,
           lateAppealReason = if (isLateAppeal) request.userAnswers.getAnswer(LateAppealPage) else None,
           isClientResponsibleForSubmission = isClientResponsibleForSubmission,
           isClientResponsibleForLateSubmission = isClientResponsibleForLateSubmission
-        )
-        )
+        ))
 
       case "crime" =>
         baseAppealSubmission(CrimeAppealInformation(
           reasonableExcuse = reasonableExcuse,
           honestyDeclaration = request.getMandatoryAnswer(HonestyDeclarationPage),
-          startDateOfEvent = request.session.get(IncomeTaxSessionKeys.dateOfCrime).map(LocalDate.parse).get.atStartOfDay(),
+          startDateOfEvent = request.getMandatoryAnswer(WhenDidEventHappenPage).atStartOfDay(),
           reportedIssueToPolice = request.getMandatoryAnswer(CrimeReportedPage),
           statement = None,
           lateAppeal = isLateAppeal,
           lateAppealReason = if (isLateAppeal) request.userAnswers.getAnswer(LateAppealPage) else None,
           isClientResponsibleForSubmission = isClientResponsibleForSubmission,
           isClientResponsibleForLateSubmission = isClientResponsibleForLateSubmission
-        )
-        )
+        ))
 
       case "fireOrFlood" =>
         baseAppealSubmission(FireOrFloodAppealInformation(
           reasonableExcuse = "fireandflood", //API spec outlines this - the frontend says 'fire or flood' (11/10/23)
           honestyDeclaration = request.getMandatoryAnswer(HonestyDeclarationPage),
-          startDateOfEvent = request.session.get(IncomeTaxSessionKeys.dateOfFireOrFlood).map(LocalDate.parse).get.atStartOfDay(),
+          startDateOfEvent = request.getMandatoryAnswer(WhenDidEventHappenPage).atStartOfDay(),
           statement = None,
           lateAppeal = isLateAppeal,
           lateAppealReason = if (isLateAppeal) request.userAnswers.getAnswer(LateAppealPage) else None,
           isClientResponsibleForSubmission = isClientResponsibleForSubmission,
           isClientResponsibleForLateSubmission = isClientResponsibleForLateSubmission
-        )
-        )
+        ))
 
       case "lossOfStaff" =>
         baseAppealSubmission(LossOfStaffAppealInformation(
           reasonableExcuse = "lossOfEssentialStaff",
           honestyDeclaration = request.getMandatoryAnswer(HonestyDeclarationPage),
-          startDateOfEvent = request.session.get(IncomeTaxSessionKeys.whenPersonLeftTheBusiness).map(LocalDate.parse).get.atStartOfDay(),
+          startDateOfEvent = request.getMandatoryAnswer(WhenDidEventHappenPage).atStartOfDay(),
           statement = None,
           lateAppeal = isLateAppeal,
           lateAppealReason = if (isLateAppeal) request.userAnswers.getAnswer(LateAppealPage) else None,
           isClientResponsibleForSubmission = isClientResponsibleForSubmission,
           isClientResponsibleForLateSubmission = isClientResponsibleForLateSubmission
-        )
-        )
+        ))
 
       case "technicalIssues" =>
         baseAppealSubmission(TechnicalIssuesAppealInformation(
           reasonableExcuse = "technicalIssue",
           honestyDeclaration = request.getMandatoryAnswer(HonestyDeclarationPage),
-          startDateOfEvent = request.session.get(IncomeTaxSessionKeys.whenDidTechnologyIssuesBegin).map(LocalDate.parse).get.atStartOfDay(),
-          endDateOfEvent = request.session.get(IncomeTaxSessionKeys.whenDidTechnologyIssuesEnd).map(LocalDate.parse).get.atStartOfDay().plusSeconds(1).truncatedTo(ChronoUnit.SECONDS),
+          startDateOfEvent = request.getMandatoryAnswer(WhenDidEventHappenPage).atStartOfDay(),
+          endDateOfEvent = request.getMandatoryAnswer(WhenDidEventEndPage).atStartOfDay().plusSeconds(1).truncatedTo(ChronoUnit.SECONDS),
           statement = None,
           lateAppeal = isLateAppeal,
           lateAppealReason = if (isLateAppeal) request.userAnswers.getAnswer(LateAppealPage) else None,
           isClientResponsibleForSubmission = isClientResponsibleForSubmission,
           isClientResponsibleForLateSubmission = isClientResponsibleForLateSubmission
-        )
-        )
+        ))
 
       case "health" =>
+        //TODO: These will need updating when we built the health flow to retrieve from User Answers
         val isHospitalStay = request.session.get(IncomeTaxSessionKeys.wasHospitalStayRequired).get == "yes"
         val isOngoingHospitalStay = request.session.get(IncomeTaxSessionKeys.hasHealthEventEnded).contains("no")
         baseAppealSubmission(HealthAppealInformation(
           reasonableExcuse = reasonableExcuse,
           honestyDeclaration = request.getMandatoryAnswer(HonestyDeclarationPage),
           hospitalStayInvolved = isHospitalStay,
-          startDateOfEvent = (if (isHospitalStay) request.session.get(IncomeTaxSessionKeys.whenHealthIssueStarted).map(LocalDate.parse(_)) else request.session.get(IncomeTaxSessionKeys.whenHealthIssueHappened).map(LocalDate.parse(_))).map(_.atStartOfDay()),
-          endDateOfEvent = if (isOngoingHospitalStay) None else request.session.get(IncomeTaxSessionKeys.whenHealthIssueEnded).map(LocalDate.parse(_).atStartOfDay().plusSeconds(1).truncatedTo(ChronoUnit.SECONDS)),
+          startDateOfEvent = request.userAnswers.getAnswer(WhenDidEventHappenPage).map(_.atStartOfDay()),
+          endDateOfEvent = Option.when(!isOngoingHospitalStay)(request.userAnswers.getAnswer(WhenDidEventEndPage).map(_.atStartOfDay().plusSeconds(1).truncatedTo(ChronoUnit.SECONDS))).flatten,
           eventOngoing = isOngoingHospitalStay,
           statement = None,
           lateAppeal = isLateAppeal,
           lateAppealReason = if (isLateAppeal) request.userAnswers.getAnswer(LateAppealPage) else None,
           isClientResponsibleForSubmission = isClientResponsibleForSubmission,
           isClientResponsibleForLateSubmission = isClientResponsibleForLateSubmission
-        )
-        )
+        ))
 
       case "other" =>
         baseAppealSubmission(OtherAppealInformation(
           reasonableExcuse = reasonableExcuse,
           honestyDeclaration = request.getMandatoryAnswer(HonestyDeclarationPage),
-          startDateOfEvent = request.session.get(IncomeTaxSessionKeys.whenDidBecomeUnable).map(LocalDate.parse).get.atStartOfDay(),
-          statement = request.session.get(IncomeTaxSessionKeys.whyReturnSubmittedLate),
-//          supportingEvidence = uploadedFiles.fold[Option[Evidence]](None)(files => if (files.isEmpty) None else Some(Evidence(files.size))),
-          supportingEvidence = None,
+          startDateOfEvent = request.getMandatoryAnswer(WhenDidEventHappenPage).atStartOfDay(),
+          statement = request.session.get(IncomeTaxSessionKeys.whyReturnSubmittedLate), //TODO: Update this when we build the page
+          supportingEvidence = uploadedFiles.fold[Option[Evidence]](None)(files => if (files.isEmpty) None else Some(Evidence(files.size))),
           lateAppeal = isLateAppeal,
           lateAppealReason = if (isLateAppeal) request.userAnswers.getAnswer(LateAppealPage) else None,
           isClientResponsibleForSubmission = isClientResponsibleForSubmission,
-          isClientResponsibleForLateSubmission = isClientResponsibleForLateSubmission
-//          uploadedFiles = if (uploadedFiles.isDefined) uploadedFiles else None
-        )
-        )
+          isClientResponsibleForLateSubmission = isClientResponsibleForLateSubmission,
+          uploadedFiles = uploadedFiles
+        ))
     }
   }
 

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/appeals/submission/OtherAppealInformation.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/appeals/submission/OtherAppealInformation.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.submission
 
 import play.api.libs.json.{Json, OFormat, Writes}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.Evidence
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.UploadJourney
 
 import java.time.LocalDateTime
 
@@ -30,8 +31,8 @@ case class OtherAppealInformation(
                                    lateAppeal: Boolean,
                                    lateAppealReason: Option[String],
                                    isClientResponsibleForSubmission: Option[Boolean],
-                                   isClientResponsibleForLateSubmission: Option[Boolean]
-//                                   uploadedFiles: Option[Seq[UploadJourney]]
+                                   isClientResponsibleForLateSubmission: Option[Boolean],
+                                   uploadedFiles: Option[Seq[UploadJourney]]
                                  ) extends AppealInformation
 
 object OtherAppealInformation {
@@ -68,13 +69,13 @@ object OtherAppealInformation {
         Json.obj()
       )(
         isClientResponsibleForLateSubmission => Json.obj("isClientResponsibleForLateSubmission" -> isClientResponsibleForLateSubmission)
-      ))
-//    ).deepMerge(
-//      otherAppealInformation.uploadedFiles.fold(
-//        Json.obj()
-//      )(
-//        uploadedFiles => Json.obj("uploadedFiles" -> uploadedFiles)
-//      )
-//    )
+      )
+    ).deepMerge(
+      otherAppealInformation.uploadedFiles.fold(
+        Json.obj()
+      )(
+        uploadedFiles => Json.obj("uploadedFiles" -> uploadedFiles)
+      )
+    )
   }
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealService.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealService.scala
@@ -109,7 +109,14 @@ class AppealService @Inject()(penaltiesConnector: PenaltiesConnector,
                            reasonableExcuse: String
                           )(implicit request: CurrentUserRequestWithAnswers[_], ec: ExecutionContext, hc: HeaderCarrier): Future[Either[Int, Unit]] = {
     val correlationId = idGenerator.generateUUID
-    val modelFromRequest: AppealSubmission = AppealSubmission.constructModelBasedOnReasonableExcuse(reasonableExcuse, isAppealLate, agentReferenceNo, mtdItId)
+    val modelFromRequest: AppealSubmission =
+      AppealSubmission.constructModelBasedOnReasonableExcuse(
+        reasonableExcuse = reasonableExcuse,
+        isLateAppeal = isAppealLate,
+        agentReferenceNo = agentReferenceNo,
+        uploadedFiles = None, //TODO: Retrieve the file uploads as part of MIPR-1406
+        mtdItId = mtdItId
+      )
     val penaltyNumber = request.session.get(IncomeTaxSessionKeys.penaltyNumber).getOrElse(throw new RuntimeException("[AppealService][singleAppeal] Penalty number not found in session"))
 
     penaltiesConnector.submitAppeal(modelFromRequest, mtdItId, isLPP, penaltyNumber, correlationId, isMultiAppeal = false).map {
@@ -135,7 +142,13 @@ class AppealService @Inject()(penaltiesConnector: PenaltiesConnector,
 
     val firstCorrelationId = idGenerator.generateUUID
     val secondCorrelationId = idGenerator.generateUUID
-    val modelFromRequest: AppealSubmission = AppealSubmission.constructModelBasedOnReasonableExcuse(reasonableExcuse, isAppealLate, agentReferenceNo, mtdItId)
+    val modelFromRequest: AppealSubmission = AppealSubmission.constructModelBasedOnReasonableExcuse(
+      reasonableExcuse = reasonableExcuse,
+      isLateAppeal = isAppealLate,
+      agentReferenceNo = agentReferenceNo,
+      uploadedFiles = None, //TODO: Retrieve the file uploads as part of
+      mtdItId = mtdItId
+    )
     val firstPenaltyNumber = request.session.get(IncomeTaxSessionKeys.firstPenaltyChargeReference).getOrElse(throw new RuntimeException("[AppealService][multipleAppeal] First penalty number not found in session"))
     val secondPenaltyNumber = request.session.get(IncomeTaxSessionKeys.secondPenaltyChargeReference).getOrElse(throw new RuntimeException("[AppealService][multipleAppeal] Second penalty number not found in session"))
     val dateFrom = request.session.get(IncomeTaxSessionKeys.startDateOfPeriod).getOrElse(throw new RuntimeException("[AppealService][multipleAppeal] Start date of period not found in session"))

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/IncomeTaxSessionKeys.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/IncomeTaxSessionKeys.scala
@@ -22,94 +22,17 @@ object IncomeTaxSessionKeys {
   val pocAchievementDate = "pocAchievementDate"
   val startDateOfPeriod = "periodStart"
   val endDateOfPeriod = "periodEnd"
-  val dueDateOfPeriod = "periodDueDate"
   val dateCommunicationSent = "dateCommunicationSent"
   val penaltyNumber = "penaltyNumber"
-  val vatAmount = "vatAmount"
-  val principalChargeReference = "principalChargeReference"
-  val isCaLpp = "isCaLpp"
-  val dateOfCrime = "dateOfCrime"
-  val dateOfFireOrFlood = "dateOfFireOrFlood"
-  val whenPersonLeftTheBusiness = "whenPersonLeftTheBusiness"
-  val whenDidTechnologyIssuesBegin = "whenDidTechnologyIssuesBegin"
-  val whenDidTechnologyIssuesEnd = "whenDidTechnologyIssuesEnd"
   val wasHospitalStayRequired = "wasHospitalStayRequired"
-  val whenHealthIssueHappened = "whenHealthIssueHappened"
-  val whenHealthIssueStarted = "whenHealthIssueStarted"
-  val whenHealthIssueEnded = "whenHealthIssueEnded"
   val hasHealthEventEnded = "hasHealthEventEnded"
-  val whenDidBecomeUnable = "whenDidBecomeUnable"
   val whyReturnSubmittedLate = "whyReturnSubmittedLate"
   val agentSessionMtditid = "ClientMTDID"
-  val whenDidThePersonDie = "whenDidThePersonDie"
-  val cancelVATRegistration = "cancelVATRegistration"
-  val otherRelevantInformation = "otherRelevantInformation"
   val journeyId = "journeyId"
-  val fileReference = "fileReference"
-  val isAddingAnotherDocument = "isAddingAnotherDocument"
-  val errorCodeFromUpscan = "errorCodeFromUpscan"
-  val failureMessageFromUpscan = "failureMessageFromUpscan"
   val isUploadEvidence = "isUploadEvidence"
-  val youCanAppealThisPenalty = "youCanAppealThisPenalty"
-  val originatingChangePage = "originatingChangePage"
   val doYouWantToAppealBothPenalties = "doYouWantToAppealBothPenalties"
   val firstPenaltyChargeReference = "firstPenaltyChargeReference"
-  val firstPenaltyAmount = "firstPenaltyAmount"
   val secondPenaltyChargeReference = "secondPenaltyChargeReference"
-  val secondPenaltyAmount = "secondPenaltyAmount"
   val firstPenaltyCommunicationDate = "firstPenaltyCommunicationDate"
   val secondPenaltyCommunicationDate = "secondPenaltyCommunicationDate"
-  val penaltiesHasSeenConfirmationPage = "penaltiesHasSeenConfirmationPage"
-  val previouslySubmittedJourneyId = "previouslySubmittedJourneyId"
-  val appealAfterPaymentPlanSetUp = "appealAfterPaymentPlanSetUp"
-  val fileNames = "fileNames"
-  val doYouWantToPayNow = "doYouWantToPayNow"
-  val willUserPay = "willUsePay"
-  val hasBusinessAskedHMRCToCancelRegistration = "hasBusinessAskedHMRCToCancelRegistration"
-  val hasHMRCConfirmedRegistrationCancellation = "hasHMRCConfirmedRegistrationCancellation"
-  val isFindOutHowToAppeal ="isFindOutHowToAppeal"
-
-  val allKeys: Seq[String] = Seq(
-    appealType,
-    startDateOfPeriod,
-    endDateOfPeriod,
-    dueDateOfPeriod,
-    penaltyNumber,
-    dateOfCrime,
-    dateOfFireOrFlood,
-    dateCommunicationSent,
-    whenPersonLeftTheBusiness,
-    whenDidTechnologyIssuesBegin,
-    whenDidTechnologyIssuesEnd,
-    wasHospitalStayRequired,
-    whenHealthIssueHappened,
-    whenHealthIssueStarted,
-    whenHealthIssueEnded,
-    whenDidBecomeUnable,
-    whyReturnSubmittedLate,
-    hasHealthEventEnded,
-    whenDidThePersonDie,
-    isFindOutHowToAppeal,
-    cancelVATRegistration,
-    otherRelevantInformation,
-    errorCodeFromUpscan,
-    failureMessageFromUpscan,
-    fileReference,
-    isAddingAnotherDocument,
-    isUploadEvidence,
-    youCanAppealThisPenalty,
-    originatingChangePage,
-    doYouWantToAppealBothPenalties,
-    firstPenaltyChargeReference,
-    firstPenaltyAmount,
-    secondPenaltyChargeReference,
-    secondPenaltyAmount,
-    firstPenaltyCommunicationDate,
-    secondPenaltyCommunicationDate,
-    doYouWantToPayNow,
-    appealAfterPaymentPlanSetUp,
-    willUserPay,
-    hasBusinessAskedHMRCToCancelRegistration,
-    hasHMRCConfirmedRegistrationCancellation
-  )
 }

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealServiceSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealServiceSpec.scala
@@ -34,7 +34,7 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.httpParsers.{Inv
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.{AppealSubmissionResponseModel, MultiplePenaltiesData}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models._
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{CrimeReportedPage, HonestyDeclarationPage, ReasonableExcusePage}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{CrimeReportedPage, HonestyDeclarationPage, ReasonableExcusePage, WhenDidEventHappenPage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{IncomeTaxSessionKeys, TimeMachine, UUIDGenerator}
 import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
@@ -62,11 +62,11 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
         .setAnswer(HonestyDeclarationPage, true)
         .setAnswer(CrimeReportedPage, CrimeReportedEnum.yes)
         .setAnswer(ReasonableExcusePage, "crime")
+        .setAnswer(WhenDidEventHappenPage, LocalDate.of(2022, 1, 1))
     )(
       //TODO: These will all move to be UserAnswers as part of future stories
       FakeRequest().withSession(
         IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
-        IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
         IncomeTaxSessionKeys.penaltyNumber -> "123456789",
         IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Submission.toString,
         IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "no"
@@ -79,11 +79,11 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
         .setAnswer(HonestyDeclarationPage, true)
         .setAnswer(CrimeReportedPage, CrimeReportedEnum.yes)
         .setAnswer(ReasonableExcusePage, "crime")
+        .setAnswer(WhenDidEventHappenPage, LocalDate.of(2022, 1, 1))
     )(
       //TODO: These will all move to be UserAnswers as part of future stories
       FakeRequest().withSession(
         IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
-        IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
         IncomeTaxSessionKeys.penaltyNumber -> "123456789",
         IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Payment.toString,
         IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "yes",
@@ -99,10 +99,10 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
       userAnswers = UserAnswers(testJourneyId)
         .setAnswer(HonestyDeclarationPage, true)
         .setAnswer(ReasonableExcusePage, "other")
+        .setAnswer(WhenDidEventHappenPage, LocalDate.of(2022, 1, 1))
     )(
       //TODO: These will all move to be UserAnswers as part of future stories
       FakeRequest().withSession(
-        IncomeTaxSessionKeys.whenDidBecomeUnable -> "2022-01-01",
         IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
         IncomeTaxSessionKeys.whyReturnSubmittedLate -> "This is a reason.",
         IncomeTaxSessionKeys.isUploadEvidence -> "yes",
@@ -117,10 +117,10 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
       userAnswers = UserAnswers(testJourneyId)
         .setAnswer(HonestyDeclarationPage, true)
         .setAnswer(ReasonableExcusePage, "other")
+        .setAnswer(WhenDidEventHappenPage, LocalDate.of(2022, 1, 1))
     )(
       //TODO: These will all move to be UserAnswers as part of future stories
       FakeRequest().withSession(
-        IncomeTaxSessionKeys.whenDidBecomeUnable -> "2022-01-01",
         IncomeTaxSessionKeys.dateCommunicationSent -> "2021-12-01",
         IncomeTaxSessionKeys.whyReturnSubmittedLate -> "This is a reason.",
         IncomeTaxSessionKeys.isUploadEvidence -> "no",
@@ -446,11 +446,11 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
           .setAnswer(HonestyDeclarationPage, true)
           .setAnswer(CrimeReportedPage, CrimeReportedEnum.yes)
           .setAnswer(ReasonableExcusePage, "crime")
+          .setAnswer(WhenDidEventHappenPage, LocalDate.of(2022, 1, 1))
       )(
         //TODO: These will all move to be UserAnswers as part of future stories
         FakeRequest().withSession(
           IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "yes",
-          IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
           IncomeTaxSessionKeys.penaltyNumber -> "123456789",
           IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Payment.toString,
           IncomeTaxSessionKeys.firstPenaltyCommunicationDate -> lpp1Date.toString,
@@ -464,11 +464,11 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
           .setAnswer(HonestyDeclarationPage, true)
           .setAnswer(CrimeReportedPage, CrimeReportedEnum.yes)
           .setAnswer(ReasonableExcusePage, "crime")
+          .setAnswer(WhenDidEventHappenPage, LocalDate.of(2022, 1, 1))
       )(
         //TODO: These will all move to be UserAnswers as part of future stories
         FakeRequest().withSession(
           IncomeTaxSessionKeys.dateCommunicationSent -> date.toString,
-          IncomeTaxSessionKeys.dateOfCrime -> "2022-01-01",
           IncomeTaxSessionKeys.penaltyNumber -> "123456789",
           IncomeTaxSessionKeys.appealType -> PenaltyTypeEnum.Late_Payment.toString
         ))


### PR DESCRIPTION
Notes:
- There are some flows/pages we've not built yet, so this will still need to change when we implement those journeys
- There are also still some Session Keys being used that we don't currently have values for, these relate to the penalty data information - which we will need to retrieve and save on the InitialisationController in a future story. 
- We need to retrieve the Upload Journey files as part of MIPR-1406 and add to the model