### PR TITLE
[MIPR-1545] Retrieve the Penalty Appeal Data and Store in UserAnswers

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
@@ -65,8 +65,6 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
   def submitAppealUrl(mtditid: String, isLPP: Boolean, penaltyNumber: String, correlationId: String, isMultiAppeal: Boolean): String =
     s"$penaltiesServiceBaseUrl/ITSA/appeals/submit-appeal/MTDITID/$mtditid?isLPP=$isLPP&penaltyNumber=$penaltyNumber&correlationId=$correlationId&isMultiAppeal=$isMultiAppeal"
 
-  lazy val daysRequiredForLateAppeal: Int = config.get[Int]("constants.daysRequiredForLateAppeal")
-
   lazy val signInUrl: String = config.get[String]("signIn.url")
   lazy val signOutUrl: String = config.get[String]("signOut.url")
 

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/AppealStartController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/AppealStartController.scala
@@ -19,8 +19,9 @@ package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.AuthAction
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{AuthAction, UserAnswersAction}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.featureswitch.core.config.FeatureSwitching
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.TimeMachine
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.AppealStartView
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.predicates.NavBarRetrievalAction
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
@@ -30,27 +31,12 @@ import javax.inject.Inject
 class AppealStartController @Inject()(appealStart: AppealStartView,
                                       val authorised: AuthAction,
                                       withNavBar: NavBarRetrievalAction,
+                                      withAnswers: UserAnswersAction,
                                       override val controllerComponents: MessagesControllerComponents
-                                     )(implicit val appConfig: AppConfig) extends FrontendBaseController with I18nSupport with FeatureSwitching {
-  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar) { implicit currentUser =>
-        //      logger.debug(s"[AppealStartController][onPageLoad] - Session keys received: \n" +
-        //        s"Appeal Type = ${userRequest.answers.getAnswer[PenaltyTypeEnum.Value](IncomeTaxSessionKeys.appealType)}, \n" +
-        //        s"Penalty Number = ${userRequest.answers.getAnswer[String](IncomeTaxSessionKeys.penaltyNumber)}, \n" +
-        //        s"Start date of period = ${userRequest.answers.getAnswer[LocalDate](IncomeTaxSessionKeys.startDateOfPeriod)}, \n" +
-        //        s"End date of period = ${userRequest.answers.getAnswer[LocalDate](IncomeTaxSessionKeys.endDateOfPeriod)}, \n" +
-        //        s"Due date of period = ${userRequest.answers.getAnswer[LocalDate](IncomeTaxSessionKeys.dueDateOfPeriod)}, \n" +
-        //        s"Is find out how to appeal = ${userRequest.answers.getAnswer[Boolean](IncomeTaxSessionKeys.isFindOutHowToAppeal)}, \n" +
-        //        s"Date communication sent of period = ${userRequest.answers.getAnswer[LocalDate](IncomeTaxSessionKeys.dateCommunicationSent)}, \n")
+                                     )(implicit timeMachine: TimeMachine, val appConfig: AppConfig) extends FrontendBaseController with I18nSupport with FeatureSwitching {
 
-
-        Ok(appealStart(
-          true, currentUser.isAgent
-        ))
+  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers) { implicit currentUser =>
+    Ok(appealStart(currentUser.isAppealLate(), currentUser.isAgent))
   }
-
-  //  private def isAppealLate()(implicit userRequest: UserRequest[_]): Boolean = {
-  //      val dateCommunicationSentParsedAsLocalDate = userRequest.answers.getAnswer[LocalDate](IncomeTaxSessionKeys.dateCommunicationSent).get
-  //      dateCommunicationSentParsedAsLocalDate.isBefore(getFeatureDate.minusDays(appConfig.daysRequiredForLateAppeal))
-  //  }
 
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ConfirmationController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ConfirmationController.scala
@@ -20,6 +20,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{AuthAction, UserAnswersAction}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.ReasonableExcusePage
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.TimeMachine
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html._
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.predicates.NavBarRetrievalAction
 
@@ -33,14 +34,11 @@ class ConfirmationController @Inject()(confirmation: ConfirmationView,
                                        withAnswers: UserAnswersAction,
                                        override val errorHandler: ErrorHandler,
                                        override val controllerComponents: MessagesControllerComponents
-                                      )(implicit ec: ExecutionContext,
-                                        val appConfig: AppConfig) extends BaseUserAnswersController {
+                                      )(implicit ec: ExecutionContext, timeMachine: TimeMachine, val appConfig: AppConfig) extends BaseUserAnswersController {
 
   def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit currentUser =>
     withAnswer(ReasonableExcusePage) { reasonableExcuse =>
-      Future(Ok(confirmation(
-        true, currentUser.isAgent, reasonableExcuse
-      )))
+      Future(Ok(confirmation(currentUser.isAppealLate(), currentUser.isAgent, reasonableExcuse)))
     }
   }
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CrimeReportedController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CrimeReportedController.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{Aut
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.CrimeReportedForm
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{CrimeReportedPage, ReasonableExcusePage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.UserAnswersService
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.TimeMachine
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html._
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.predicates.NavBarRetrievalAction
 
@@ -36,14 +37,14 @@ class CrimeReportedController @Inject()(hasTheCrimeBeenReported: HasTheCrimeBeen
                                         userAnswersService: UserAnswersService,
                                         override val errorHandler: ErrorHandler,
                                         override val controllerComponents: MessagesControllerComponents
-                                       )(implicit ec: ExecutionContext, val appConfig: AppConfig) extends BaseUserAnswersController {
+                                       )(implicit ec: ExecutionContext, timeMachine: TimeMachine, val appConfig: AppConfig) extends BaseUserAnswersController {
 
-  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit currentUser =>
+  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>
     withAnswer(ReasonableExcusePage) { reasonableExcuse =>
       Future(Ok(hasTheCrimeBeenReported(
         form = fillForm(CrimeReportedForm.form(), CrimeReportedPage),
-        isLate = true,
-        isAgent = currentUser.isAgent,
+        isLate = user.isAppealLate(),
+        isAgent = user.isAgent,
         reasonableExcuseMessageKey = reasonableExcuse
       )))
     }
@@ -55,7 +56,7 @@ class CrimeReportedController @Inject()(hasTheCrimeBeenReported: HasTheCrimeBeen
         withAnswer(ReasonableExcusePage) { reasonableExcuse =>
           Future(BadRequest(hasTheCrimeBeenReported(
             form = formWithErrors,
-            isLate = true,
+            isLate = user.isAppealLate(),
             isAgent = user.isAgent,
             reasonableExcuseMessageKey = reasonableExcuse
           )))

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CrimeReportedController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CrimeReportedController.scala
@@ -64,7 +64,11 @@ class CrimeReportedController @Inject()(hasTheCrimeBeenReported: HasTheCrimeBeen
       value => {
         val updatedAnswers = user.userAnswers.setAnswer(CrimeReportedPage, value)
         userAnswersService.updateAnswers(updatedAnswers).map { _ =>
-          Redirect(routes.LateAppealController.onPageLoad())
+          if(user.isAppealLate()) {
+            Redirect(routes.LateAppealController.onPageLoad())
+          } else {
+            Redirect(routes.CheckYourAnswersController.onPageLoad())
+          }
         }
       }
     )

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ExtraEvidenceController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ExtraEvidenceController.scala
@@ -17,9 +17,9 @@
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{AuthAction, UserAnswersAction}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.ErrorHandler
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{AuthAction, UserAnswersAction}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.ExtraEvidenceForm
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{ExtraEvidencePage, ReasonableExcusePage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.{UpscanService, UserAnswersService}
@@ -38,7 +38,7 @@ class ExtraEvidenceController @Inject()(extraEvidence: ExtraEvidenceView,
                                         userAnswersService: UserAnswersService,
                                         override val errorHandler: ErrorHandler,
                                         override val controllerComponents: MessagesControllerComponents
-                                       )(implicit ec: ExecutionContext, val appConfig: AppConfig) extends BaseUserAnswersController {
+                                       )(implicit ec: ExecutionContext) extends BaseUserAnswersController {
 
   def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit currentUser =>
     withAnswer(ReasonableExcusePage) { reasonableExcuse =>

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ExtraEvidenceController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ExtraEvidenceController.scala
@@ -70,7 +70,11 @@ class ExtraEvidenceController @Inject()(extraEvidence: ExtraEvidenceView,
             Future(Redirect(controllers.upscan.routes.UpscanCheckAnswersController.onPageLoad()))
           } else {
             upscanService.removeAllFiles(user.journeyId).map(_ =>
-              Redirect(controllers.routes.LateAppealController.onPageLoad())
+              if(user.isAppealLate()) {
+                Redirect(routes.LateAppealController.onPageLoad())
+              } else {
+                Redirect(routes.CheckYourAnswersController.onPageLoad())
+              }
             )
           }
         }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationController.scala
@@ -55,7 +55,7 @@ class InitialisationController @Inject()(val authorised: AuthAction,
 
   private def storyPenaltyDataAndRedirect(penaltyId: String,
                                           appealModel: AppealData,
-                                          multiPenaltiesModel: Option[MultiplePenaltiesData] = None)(implicit user: CurrentUserRequest[_]): Future[Result] = {
+                                          multiPenaltiesModel: Option[MultiplePenaltiesData])(implicit user: CurrentUserRequest[_]): Future[Result] = {
 
     val journeyId = uuid.generateUUID
     logger.debug(s"[InitialisationController][onPageLoad] Starting journey for penaltyId: $penaltyId, created journeyId: $journeyId")

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ViewAppealDetailsController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ViewAppealDetailsController.scala
@@ -20,6 +20,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{AuthAction, UserAnswersAction}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.ReasonableExcusePage
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.TimeMachine
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html._
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.predicates.NavBarRetrievalAction
 
@@ -33,12 +34,12 @@ class ViewAppealDetailsController @Inject()(viewAppealDetails: ViewAppealDetails
                                             withAnswers: UserAnswersAction,
                                             override val errorHandler: ErrorHandler,
                                             override val controllerComponents: MessagesControllerComponents,
-                                           )(implicit ec: ExecutionContext, val appConfig: AppConfig) extends BaseUserAnswersController {
+                                           )(implicit ec: ExecutionContext, timeMachine: TimeMachine, val appConfig: AppConfig) extends BaseUserAnswersController {
 
-  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit currentUser =>
+  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>
     withAnswer(ReasonableExcusePage) { reasonableExcuse =>
       Future(Ok(viewAppealDetails(
-        true, currentUser.isAgent, reasonableExcuse
+        user.isAppealLate(), user.isAgent, reasonableExcuse
       )))
     }
   }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhatCausedYouToMissDeadlineController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhatCausedYouToMissDeadlineController.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{Aut
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.WhatCausedYouToMissDeadlineForm
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.WhatCausedYouToMissDeadlinePage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.UserAnswersService
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.TimeMachine
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html._
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.predicates.NavBarRetrievalAction
 
@@ -36,12 +37,12 @@ class WhatCausedYouToMissDeadlineController @Inject()(whatCausedYouToMissTheDead
                                                       userAnswersService: UserAnswersService,
                                                       override val errorHandler: ErrorHandler,
                                                       override val controllerComponents: MessagesControllerComponents
-                                                     )(implicit ec: ExecutionContext, val appConfig: AppConfig) extends BaseUserAnswersController {
+                                                     )(implicit ec: ExecutionContext, timeMachine: TimeMachine, val appConfig: AppConfig) extends BaseUserAnswersController {
 
   def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers) { implicit user =>
     Ok(whatCausedYouToMissTheDeadline(
       fillForm(WhatCausedYouToMissDeadlineForm.form(), WhatCausedYouToMissDeadlinePage),
-      true,
+      user.isAppealLate(),
       user.isAgent
     ))
   }
@@ -52,7 +53,7 @@ class WhatCausedYouToMissDeadlineController @Inject()(whatCausedYouToMissTheDead
       formWithErrors =>
         Future(BadRequest(whatCausedYouToMissTheDeadline(
           formWithErrors,
-          true,
+          user.isAppealLate(),
           user.isAgent
         ))),
       value => {

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventEndController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventEndController.scala
@@ -66,7 +66,11 @@ class WhenDidEventEndController @Inject()(whenDidEventEnd: WhenDidEventEndView,
           dateOfEvent => {
             val updatedAnswers = user.userAnswers.setAnswer(WhenDidEventEndPage, dateOfEvent)
             userAnswersService.updateAnswers(updatedAnswers).map { _ =>
-              Redirect(routes.LateAppealController.onPageLoad())
+              if(user.isAppealLate()) {
+                Redirect(routes.LateAppealController.onPageLoad())
+              } else {
+                Redirect(routes.CheckYourAnswersController.onPageLoad())
+              }
             }
           })
       }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenController.scala
@@ -67,7 +67,11 @@ class WhenDidEventHappenController @Inject()(whenDidEventHappen: WhenDidEventHap
               case "technicalIssues" =>
                 Redirect(routes.WhenDidEventEndController.onPageLoad())
               case "bereavement" | "fireOrFlood" =>
-                Redirect(routes.LateAppealController.onPageLoad())
+                if(user.isAppealLate()) {
+                  Redirect(routes.LateAppealController.onPageLoad())
+                } else {
+                  Redirect(routes.CheckYourAnswersController.onPageLoad())
+                }
               case "crime" =>
                 Redirect(routes.CrimeReportedController.onPageLoad())
               case _ =>

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenController.scala
@@ -46,7 +46,7 @@ class WhenDidEventHappenController @Inject()(whenDidEventHappen: WhenDidEventHap
       Future(Ok(whenDidEventHappen(
         form = fillForm(WhenDidEventHappenForm.form(reasonableExcuse), WhenDidEventHappenPage),
         reasonableExcuseMessageKey = reasonableExcuse,
-        isLPP = false //TODO: Need to determine this as part of a future story
+        isLPP = user.isLPP
       )))
     }
   }
@@ -58,7 +58,7 @@ class WhenDidEventHappenController @Inject()(whenDidEventHappen: WhenDidEventHap
           Future.successful(BadRequest(whenDidEventHappen(
             reasonableExcuse,
             formWithErrors,
-            isLPP = false //TODO: Need to determine this as part of a future story
+            isLPP = user.isLPP
           ))),
         dateOfEvent => {
           val updatedAnswers = user.userAnswers.setAnswer[LocalDate](WhenDidEventHappenPage, dateOfEvent)

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhoPlannedToSubmitController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhoPlannedToSubmitController.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{Aut
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.WhoPlannedToSubmitForm
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.WhoPlannedToSubmitPage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.UserAnswersService
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.TimeMachine
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html._
 import uk.gov.hmrc.incometaxpenaltiesfrontend.controllers.predicates.NavBarRetrievalAction
 
@@ -36,12 +37,12 @@ class WhoPlannedToSubmitController @Inject()(whoPlannedToSubmit: WhoPlannedToSub
                                              userAnswersService: UserAnswersService,
                                              override val errorHandler: ErrorHandler,
                                              override val controllerComponents: MessagesControllerComponents
-                                            )(implicit ec: ExecutionContext, val appConfig: AppConfig) extends BaseUserAnswersController {
+                                            )(implicit ec: ExecutionContext, timeMachine: TimeMachine, val appConfig: AppConfig) extends BaseUserAnswersController {
 
   def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers) { implicit user =>
     Ok(whoPlannedToSubmit(
       fillForm(WhoPlannedToSubmitForm.form(), WhoPlannedToSubmitPage),
-      isLate = true,
+      user.isAppealLate(),
       user.isAgent
     ))
   }
@@ -52,7 +53,7 @@ class WhoPlannedToSubmitController @Inject()(whoPlannedToSubmit: WhoPlannedToSub
       formWithErrors =>
         Future(BadRequest(whoPlannedToSubmit(
           formWithErrors,
-          isLate = true,
+          user.isAppealLate(),
           user.isAgent
         ))),
       whoPlannedToSubmit => {

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanRemoveFileController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanRemoveFileController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.upscan
 
 import play.api.data.Form
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.ErrorHandler
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.BaseUserAnswersController
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.predicates.{AuthAction, UserAnswersAction}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan.UploadRemoveFileForm
@@ -39,7 +39,7 @@ class UpscanRemoveFileController @Inject()(nonJsRemoveFile: NonJsRemoveFileView,
                                            withAnswers: UserAnswersAction,
                                            override val errorHandler: ErrorHandler,
                                            override val controllerComponents: MessagesControllerComponents
-                                          )(implicit ec: ExecutionContext, appConfig: AppConfig) extends BaseUserAnswersController {
+                                          )(implicit ec: ExecutionContext) extends BaseUserAnswersController {
 
   def onPageLoad(fileReference: String, index: Int): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>
     renderView(Ok, UploadRemoveFileForm.form(), fileReference, index)

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/WhenDidEventHappenForm.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/WhenDidEventHappenForm.scala
@@ -36,8 +36,7 @@ import play.api.data.Form
 import play.api.i18n.Messages
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.mappings.Mappings
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{AgentClientEnum, CurrentUserRequestWithAnswers}
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{WhatCausedYouToMissDeadlinePage, WhoPlannedToSubmitPage}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.TimeMachine
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.helpers.WhenDidEventHappenHelper
 

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswers.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswers.scala
@@ -63,7 +63,7 @@ case class CurrentUserRequestWithAnswers[A](mtdItId: String,
     if(userAnswers.getAnswer(ReasonableExcusePage).exists(_.contains("bereavement"))) appConfig.bereavementLateDays else appConfig.lateDays
 
   def isAppealLate()(implicit timeMachine: TimeMachine, appConfig: AppConfig): Boolean = {
-    val dateWhereLateAppealIsApplicable: LocalDate = timeMachine.getCurrentDate.minusDays(appConfig.daysRequiredForLateAppeal)
+    val dateWhereLateAppealIsApplicable: LocalDate = timeMachine.getCurrentDate.minusDays(lateAppealDays())
 
     //TODO: This will be replaced by UserAnswers value in future story when page is built
     if (request.session.get(IncomeTaxSessionKeys.doYouWantToAppealBothPenalties).contains("yes")) {

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswers.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswers.scala
@@ -24,12 +24,30 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{Page, ReasonableExcusePage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 
+import java.time.LocalDate
+
 case class CurrentUserRequestWithAnswers[A](mtdItId: String,
                                             arn: Option[String] = None,
                                             override val navBar: Option[Html] = None,
-                                            userAnswers: UserAnswers)(implicit val request: Request[A]) extends WrappedRequest[A](request) with RequestWithNavBar {
-  val isAgent: Boolean = arn.isDefined
+                                            userAnswers: UserAnswers,
+                                            penaltyData: PenaltyData)(implicit val request: Request[A]) extends WrappedRequest[A](request) with RequestWithNavBar {
+
   val journeyId: String = userAnswers.journeyId
+  val isAgent: Boolean = arn.isDefined
+
+  //Penalty Data
+  val penaltyNumber: String = penaltyData.penaltyNumber
+  val periodStartDate: LocalDate = penaltyData.appealData.startDate
+  val periodEndDate: LocalDate = penaltyData.appealData.endDate
+  val communicationSent: LocalDate = penaltyData.appealData.dateCommunicationSent
+  val isLPP: Boolean = penaltyData.isLPP
+  val isAdditional: Boolean = penaltyData.isAdditional
+
+  //Multiple Penalties Data
+  val firstPenaltyNumber: Option[String] = penaltyData.multiplePenaltiesData.map(_.firstPenaltyChargeReference)
+  val secondPenaltyNumber: Option[String] = penaltyData.multiplePenaltiesData.map(_.secondPenaltyChargeReference)
+  val firstPenaltyCommunicationDate: Option[LocalDate] = penaltyData.multiplePenaltiesData.map(_.firstPenaltyCommunicationDate)
+  val secondPenaltyCommunicationDate: Option[LocalDate] = penaltyData.multiplePenaltiesData.map(_.secondPenaltyCommunicationDate)
 
   def getMandatoryAnswer[T](page: Page[T])(implicit reads: Reads[T]): T =
     userAnswers.getAnswer(page) match {
@@ -44,6 +62,6 @@ case class CurrentUserRequestWithAnswers[A](mtdItId: String,
 }
 
 object CurrentUserRequestWithAnswers {
-  def apply[A](userAnswers: UserAnswers)(implicit userRequest: CurrentUserRequest[A]): CurrentUserRequestWithAnswers[A] =
-    CurrentUserRequestWithAnswers(userRequest.mtdItId, userRequest.arn, userRequest.navBar, userAnswers)
+  def apply[A](userAnswers: UserAnswers, penaltyData: PenaltyData)(implicit userRequest: CurrentUserRequest[A]): CurrentUserRequestWithAnswers[A] =
+    CurrentUserRequestWithAnswers(userRequest.mtdItId, userRequest.arn, userRequest.navBar, userAnswers, penaltyData)
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/PenaltyData.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/PenaltyData.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models
+
+import play.api.libs.json.{Format, Json}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.MultiplePenaltiesData
+
+case class PenaltyData(penaltyNumber: String,
+                       appealData: AppealData,
+                       multiplePenaltiesData: Option[MultiplePenaltiesData]) {
+
+  val isLPP: Boolean = Seq(PenaltyTypeEnum.Late_Payment, PenaltyTypeEnum.Additional).contains(appealData.`type`)
+  val isAdditional: Boolean = appealData.`type` == PenaltyTypeEnum.Additional
+}
+
+object PenaltyData {
+  implicit val format: Format[PenaltyData] = Json.format[PenaltyData]
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/appeals/AppealSubmission.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/appeals/AppealSubmission.scala
@@ -61,9 +61,8 @@ object AppealSubmission {
                                             uploadedFiles: Option[Seq[UploadJourney]],
                                             mtdItId: String)
                                            (implicit request: CurrentUserRequestWithAnswers[_]): AppealSubmission = {
-    val isLPP: Boolean = !request.session.get(IncomeTaxSessionKeys.appealType).contains(PenaltyTypeEnum.Late_Submission.toString)
-    val isClientResponsibleForSubmission: Option[Boolean] = if (isLPP && agentReferenceNo.isDefined) Some(true) else request.userAnswers.getAnswer(WhoPlannedToSubmitPage).map(_ == AgentClientEnum.client)
-    val isClientResponsibleForLateSubmission: Option[Boolean] = if (isLPP && agentReferenceNo.isDefined) Some(true)
+    val isClientResponsibleForSubmission: Option[Boolean] = if (request.isLPP && agentReferenceNo.isDefined) Some(true) else request.userAnswers.getAnswer(WhoPlannedToSubmitPage).map(_ == AgentClientEnum.client)
+    val isClientResponsibleForLateSubmission: Option[Boolean] = if (request.isLPP && agentReferenceNo.isDefined) Some(true)
     else if (request.userAnswers.getAnswer(WhoPlannedToSubmitPage).contains(AgentClientEnum.agent)) {
       request.userAnswers.getAnswer(WhatCausedYouToMissDeadlinePage).map(_ == AgentClientEnum.client)
     } else None
@@ -73,7 +72,7 @@ object AppealSubmission {
       taxRegime = "ITSA",
       customerReferenceNo = s"MTDITID$mtdItId",
       dateOfAppeal = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS),
-      isLPP = isLPP,
+      isLPP = request.isLPP,
       appealSubmittedBy = if (agentReferenceNo.isDefined) "agent" else "customer",
       agentDetails = if (agentReferenceNo.isDefined) Some(constructAgentDetails(agentReferenceNo)) else None,
       appealInformation = appealInfo

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/appeals/MultiplePenaltiesData.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/appeals/MultiplePenaltiesData.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals
 
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{Format, Json}
 
 import java.time.LocalDate
 
@@ -30,5 +30,5 @@ case class MultiplePenaltiesData(
                                 )
 
 object MultiplePenaltiesData {
-  implicit val format: Reads[MultiplePenaltiesData] = Json.reads[MultiplePenaltiesData]
+  implicit val format: Format[MultiplePenaltiesData] = Json.format[MultiplePenaltiesData]
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealService.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealService.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services
 
 import play.api.http.Status._
 import play.api.libs.json.{JsResult, Json}
-import play.api.mvc.Request
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.PenaltiesConnector
@@ -27,9 +26,9 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.featureswitch.core.config.F
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.{AppealSubmission, AppealSubmissionResponseModel, MultiplePenaltiesData}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.UploadJourney
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{AppealData, CurrentUserRequestWithAnswers, PenaltyTypeEnum, ReasonableExcuse}
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{EnrolmentUtil, IncomeTaxSessionKeys, TimeMachine, UUIDGenerator}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.PagerDutyHelper.PagerDutyKeys
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{IncomeTaxSessionKeys, TimeMachine, UUIDGenerator}
 
 import java.time.LocalDate
 import javax.inject.{Inject, Singleton}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/DateFormatter.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/DateFormatter.scala
@@ -25,12 +25,6 @@ trait DateFormatter {
   def dateToString(date: LocalDate)(implicit messages: Messages): String =
     htmlNonBroken(s"${date.getDayOfMonth} ${messages(s"month.${date.getMonthValue}")} ${date.getYear}")
 
-  def dateNonBreakingSpaceMultiple(from: String, to: String)(implicit messages: Messages): String =
-    htmlNonBroken(messages("date.from.to", from, to))
-
-  def dateNonBreakingSpaceSingle(date: String): String =
-    htmlNonBroken(date)
-
   def htmlNonBroken(string: String): String =
     string.replace(" ", "\u00A0")
 

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/DateFormatter.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/DateFormatter.scala
@@ -22,19 +22,14 @@ import java.time.LocalDate
 
 trait DateFormatter {
 
-  def dateToString(date: LocalDate)(implicit messages: Messages): String = {
-    val dateNonBreaking = s"${date.getDayOfMonth} ${messages(s"month.${date.getMonthValue}")} ${date.getYear}"
-    dateNonBreaking.replace(" ", "\u00A0")
-  }
+  def dateToString(date: LocalDate)(implicit messages: Messages): String =
+    htmlNonBroken(s"${date.getDayOfMonth} ${messages(s"month.${date.getMonthValue}")} ${date.getYear}")
 
   def dateNonBreakingSpaceMultiple(from: String, to: String)(implicit messages: Messages): String =
-    messages(
-      "date.from.to",
-      htmlNonBroken(from).format(from),
-      htmlNonBroken(to).format(to)
-    )
+    htmlNonBroken(messages("date.from.to", from, to))
 
-  def dateNonBreakingSpaceSingle(date: String)(implicit messages: Messages): String = htmlNonBroken(date).format(date)
+  def dateNonBreakingSpaceSingle(date: String): String =
+    htmlNonBroken(date)
 
   def htmlNonBroken(string: String): String =
     string.replace(" ", "\u00A0")

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/EnrolmentUtil.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/EnrolmentUtil.scala
@@ -51,7 +51,4 @@ object EnrolmentUtil {
 
   }
 
-  def buildItsaEnrolment(mtdItid: String) : String =
-    incomeTaxEnrolmentKey + "~" + mtdItIdKey + "~" + mtdItid
-
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/IncomeTaxSessionKeys.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/IncomeTaxSessionKeys.scala
@@ -17,22 +17,21 @@
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils
 
 object IncomeTaxSessionKeys {
+
+  //Global keys that are used across MTD programme
   val origin = "Origin"
-  val appealType = "appealType"
-  val pocAchievementDate = "pocAchievementDate"
-  val startDateOfPeriod = "periodStart"
-  val endDateOfPeriod = "periodEnd"
-  val dateCommunicationSent = "dateCommunicationSent"
-  val penaltyNumber = "penaltyNumber"
+  val agentSessionMtditid = "ClientMTDID"
+
+  //Local keys that are only used for ITSAPR.
+  val appealType = "ITSAPR_AppealType"
+  val pocAchievementDate = "ITSAPR_pocAchievementDate"
+  val journeyId = "ITSAPR_journeyId"
+  val penaltyData = "ITSAPR_penaltyData"
+
+  //TODO: Remove all these when their answer has been moved into UserAnswers
+  val whyReturnSubmittedLate = "whyReturnSubmittedLate"
   val wasHospitalStayRequired = "wasHospitalStayRequired"
   val hasHealthEventEnded = "hasHealthEventEnded"
-  val whyReturnSubmittedLate = "whyReturnSubmittedLate"
-  val agentSessionMtditid = "ClientMTDID"
-  val journeyId = "journeyId"
   val isUploadEvidence = "isUploadEvidence"
   val doYouWantToAppealBothPenalties = "doYouWantToAppealBothPenalties"
-  val firstPenaltyChargeReference = "firstPenaltyChargeReference"
-  val secondPenaltyChargeReference = "secondPenaltyChargeReference"
-  val firstPenaltyCommunicationDate = "firstPenaltyCommunicationDate"
-  val secondPenaltyCommunicationDate = "secondPenaltyCommunicationDate"
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/WhenDidEventEndSummary.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/WhenDidEventEndSummary.scala
@@ -33,7 +33,7 @@ object WhenDidEventEndSummary extends SummaryListRowHelper with DateFormatter {
       WhenDidEventEndPage.value.map { endDate =>
         summaryListRow(
           label = messages(s"checkYourAnswers.whenDidTheEventEnd.$reasonableExcuse.key"),
-          value = Html(DateFormatter.dateNonBreakingSpaceSingle(dateToString(endDate))),
+          value = Html(dateToString(endDate)),
           actions = Some(Actions(
             items = Seq(
               ActionItem(

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/WhenDidEventHappenSummary.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/WhenDidEventHappenSummary.scala
@@ -33,7 +33,7 @@ object WhenDidEventHappenSummary extends SummaryListRowHelper with DateFormatter
       WhenDidEventHappenPage.value.map { whenDidEventHappen =>
         summaryListRow(
           label = messages(s"checkYourAnswers.whenDidEventHappen.$reasonableExcuse.key"),
-          value = Html(DateFormatter.dateNonBreakingSpaceSingle(dateToString(whenDidEventHappen))),
+          value = Html(dateToString(whenDidEventHappen)),
           actions = Some(Actions(
             items = Seq(
               ActionItem(

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/AppealStartView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/AppealStartView.scala.html
@@ -15,22 +15,24 @@
  *@
 
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.Layout
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components._
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components
 
-@this(layout: Layout,
-        p:P,
-        h1: H1,
-        h2:H2,
-        link: Link)
-
-@(isLate: Boolean, isAgent: Boolean)(implicit request: Request[_], messages: Messages)
+@this(
+        layout: Layout,
+        caption: components.PenaltyCaption,
+        p: components.P,
+        h1: components.H1,
+        h2: components.H2,
+        link: components.Link
+)
+@(isLate: Boolean, isAgent: Boolean)(implicit user: CurrentUserRequestWithAnswers[_], messages: Messages)
 
 @layout(Some(titleBuilder(messages("service.indexPageTitle"))), backLinkEnabled = false) {
 
-    <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption") @DateFormatter.dateNonBreakingSpaceMultiple("6 July 2027", "5 October 2027")</span>
+    @caption()
     @h1("appeal.start.header")
     @p("appeal.start.p1")
     @p("appeal.start.p2")

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/CheckYourAnswersView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/CheckYourAnswersView.scala.html
@@ -22,14 +22,17 @@
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.UploadJourney
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter
 
-@this(layout: Layout,
+@this(
+        layout: Layout,
         govukButton: GovukButton,
         govukSummaryList: GovukSummaryList,
         formHelper: FormWithCSRF,
         helper: CheckAnswersHelper,
+        caption: components.PenaltyCaption,
         warning: components.WarningText,
         h1: components.H1,
-        h2: components.H2)
+        h2: components.H2
+)
 
 @(isLate: Boolean, isAgent: Boolean, reasonableExcuseMessageKey: String, uploadedFiles: Seq[UploadJourney])(implicit user: CurrentUserRequestWithAnswers[_], messages: Messages)
 
@@ -37,7 +40,7 @@
 
     @formHelper(action = uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.routes.CheckYourAnswersController.submit()) {
 
-        <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption") @DateFormatter.dateNonBreakingSpaceMultiple("6 July 2027", "5 October 2027")</span>
+        @caption()
         @h1("checkYourAnswers.headingAndTitle")
         @h2("checkYourAnswers.appealDetails.h2", elmId = "appealDetails")
 

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/ConfirmationView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/ConfirmationView.scala.html
@@ -34,7 +34,7 @@
 
     @govukPanel(Panel(
         title = Text(messages("appealConfirmation.headingAndTitle")),
-        content = HtmlContent(messages("appealConfirmation.typeAndPeriod", "Late payment penalty", DateFormatter.dateNonBreakingSpaceSingle("2027 to 2028")))
+        content = HtmlContent(messages("appealConfirmation.typeAndPeriod", "Late payment penalty", DateFormatter.htmlNonBroken("2027 to 2028")))
     ))
 
     @p("appealConfirmation.p1", elmId = Some("confirmationFistParagraph"))

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/ExtraEvidenceView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/ExtraEvidenceView.scala.html
@@ -16,7 +16,6 @@
 
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
 @import uk.gov.hmrc.govukfrontend.views.html.components._
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.ExtraEvidenceForm
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.ErrorSummaryViewModel
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
@@ -35,7 +34,7 @@
         isLate: Boolean,
         isAgent: Boolean,
         reasonableExcuseMessageKey: String
-)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+)(implicit request: Request[_], messages: Messages)
 
 
 @layout(pageTitle = Some(titleBuilder(messages("extraEvidence.headingAndTitle"), Some(form))), backLinkEnabled = true) {

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/ExtraEvidenceView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/ExtraEvidenceView.scala.html
@@ -21,21 +21,23 @@
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.helpers.YesNoRadioHelper
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.Layout
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 
 @this(
         layout: Layout,
         govukErrorSummary: GovukErrorSummary,
         govukButton: GovukButton,
         formHelper: FormWithCSRF,
-        govukRadios : GovukRadios
+        govukRadios : GovukRadios,
+        caption: components.PenaltyCaption
 )
 
 @(form: Form[_],
         isLate: Boolean,
         isAgent: Boolean,
         reasonableExcuseMessageKey: String
-)(implicit request: Request[_], messages: Messages)
-
+)(implicit request: CurrentUserRequestWithAnswers[_], messages: Messages)
 
 @layout(pageTitle = Some(titleBuilder(messages("extraEvidence.headingAndTitle"), Some(form))), backLinkEnabled = true) {
 
@@ -45,25 +47,25 @@
 
     @formHelper(action = uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.routes.ExtraEvidenceController.submit()) {
 
-        <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption")</span>
+        @caption()
 
-            @govukRadios(Radios(
-                fieldset = Some(Fieldset(
-                    legend = Some(Legend(
-                        content = Text(messages("extraEvidence.headingAndTitle")),
-                        classes = "govuk-fieldset__legend--l",
-                        isPageHeading = true
-                    ))
-                )),
-                name = ExtraEvidenceForm.key,
-                hint = Some(Hint(content = Text(messages("extraEvidence.hint")))),
-                items = YesNoRadioHelper.radios(),
-                classes = "govuk-radios--inline"
-            ).withFormField(form(ExtraEvidenceForm.key)))
+        @govukRadios(Radios(
+            fieldset = Some(Fieldset(
+                legend = Some(Legend(
+                    content = Text(messages("extraEvidence.headingAndTitle")),
+                    classes = "govuk-fieldset__legend--l",
+                    isPageHeading = true
+                ))
+            )),
+            name = ExtraEvidenceForm.key,
+            hint = Some(Hint(content = Text(messages("extraEvidence.hint")))),
+            items = YesNoRadioHelper.radios(),
+            classes = "govuk-radios--inline"
+        ).withFormField(form(ExtraEvidenceForm.key)))
 
 
-            <div class="govuk-form-group">
-                @govukButton(Button(content = Text(messages("common.continue"))))
-            </div>
+        <div class="govuk-form-group">
+        @govukButton(Button(content = Text(messages("common.continue"))))
+        </div>
     }
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/HasTheCrimeBeenReportedView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/HasTheCrimeBeenReportedView.scala.html
@@ -21,20 +21,22 @@
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.ErrorSummaryViewModel
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.Layout
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 
 @this(layout: Layout,
         govukButton : GovukButton,
         govukErrorSummary: GovukErrorSummary,
         formHelper: FormWithCSRF,
-        govukRadios : GovukRadios)
+        govukRadios : GovukRadios,
+        caption: components.PenaltyCaption)
 
 @(
         form: Form[_],
         isLate: Boolean,
         isAgent: Boolean,
         reasonableExcuseMessageKey: String
-)(implicit request: Request[_], messages: Messages)
+)(implicit request: CurrentUserRequestWithAnswers[_], messages: Messages)
 
 @layout(Some(titleBuilder(messages("crime.headingAndTitle"), Some(form))), backLinkEnabled = true) {
 
@@ -44,7 +46,7 @@
 
     @formHelper(action = uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.routes.CrimeReportedController.submit()) {
 
-        <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption") @DateFormatter.dateNonBreakingSpaceMultiple("6 July 2027", "5 October 2027")</span>
+        @caption()
 
         @govukRadios(Radios(
             fieldset = Some(Fieldset(

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/HonestyDeclarationView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/HonestyDeclarationView.scala.html
@@ -17,35 +17,37 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.Layout
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components._
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter
 
-
 @this(layout: Layout,
-      govukButton : GovukButton,
-      formHelper: FormWithCSRF,
-      p:P,
-      h1: H1)
+        govukButton : GovukButton,
+        formHelper: FormWithCSRF,
+        p: components.P,
+        h1: components.H1,
+        caption: components.PenaltyCaption
+)
 
-@(isAgent: Boolean, reasonableExcuseMessageKey: String)(implicit request: Request[_], messages: Messages)
+@(isAgent: Boolean, reasonableExcuseMessageKey: String)(implicit request: CurrentUserRequestWithAnswers[_], messages: Messages)
 
 @layout(Some(titleBuilder(messages("honestyDeclaration.headingAndTitle"))), backLinkEnabled = true) {
 
-    <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption") @DateFormatter.dateNonBreakingSpaceMultiple("6 July 2027", "5 October 2027")</span>
+    @caption()
 
     @h1("honestyDeclaration.headingAndTitle")
     @p("honestyDeclaration.p1", elmId = Some("honestyDeclarationConfirm"))
 
     <ul class="govuk-list govuk-list--bullet">
-     <li id="honestyDeclarationReason">@messages(s"clientSubmitted.honestyDeclaration.li.$reasonableExcuseMessageKey", DateFormatter.dateNonBreakingSpaceSingle("5 November 2027"))</li>
-     <li id="honestyDeclaration">@messages("honestyDeclaration.li.2")</li>
+        <li id="honestyDeclarationReason">@messages(s"clientSubmitted.honestyDeclaration.li.$reasonableExcuseMessageKey", DateFormatter.dateToString(request.periodDueDate))</li>
+        <li id="honestyDeclaration">@messages("honestyDeclaration.li.2")</li>
     </ul>
 
     @formHelper(action = uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.routes.HonestyDeclarationController.submit()) {
         <div class="govuk-form-group">
-            @govukButton(Button(
-                content = Text(messages("common.acceptAndContinue"))
-            ))
+        @govukButton(Button(
+            content = Text(messages("common.acceptAndContinue"))
+        ))
         </div>
     }
 

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/LateAppealView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/LateAppealView.scala.html
@@ -18,7 +18,7 @@
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.ErrorSummaryViewModel
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.Layout
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components._
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.LateAppealForm
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
@@ -30,8 +30,9 @@
         formHelper: FormWithCSRF,
         govukCharacterCount: GovukCharacterCount,
         govukErrorSummary: GovukErrorSummary,
-        p:P,
-        h1: H1)
+        p: components.P,
+        h1: components.H1,
+        caption: components.PenaltyCaption)
 
 @(form: Form[_])(implicit user: CurrentUserRequestWithAnswers[_], messages: Messages, appConfig: AppConfig)
 
@@ -43,7 +44,7 @@
 
     @formHelper(action = uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.routes.LateAppealController.submit()) {
 
-        <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption") @DateFormatter.dateNonBreakingSpaceMultiple("6 July 2027", "5 October 2027")</span>
+        @caption()
 
         @h1(s"lateAppeal.headingAndTitle", args = Seq(user.lateAppealDays()))
         @p(s"lateAppeal.p1", elmId = Some("infoDaysParagraph"), args = Seq(user.lateAppealDays()))

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/ReasonableExcuseView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/ReasonableExcuseView.scala.html
@@ -19,16 +19,18 @@
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.ErrorSummaryViewModel
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.Layout
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 
 
 @this(layout: Layout,
       govukRadios : GovukRadios,
       formHelper: FormWithCSRF,
       govukErrorSummary: GovukErrorSummary,
-      govukButton : GovukButton)
+      govukButton : GovukButton,
+      caption: components.PenaltyCaption)
 
-@(isAgent: Boolean, form: Form[_])(implicit request: Request[_], messages: Messages)
+@(isAgent: Boolean, form: Form[_])(implicit request: CurrentUserRequestWithAnswers[_], messages: Messages)
 
 @standardOrAgent = {@if(isAgent){agent} else {standard}}
 
@@ -40,7 +42,7 @@
 
     @formHelper(action = uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.routes.ReasonableExcuseController.submit()) {
 
-        <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption") @DateFormatter.dateNonBreakingSpaceMultiple("6 July 2027", "5 October 2027")</span>
+        @caption()
 
         @govukRadios(Radios(
             fieldset = Some(Fieldset(

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/ViewAppealDetailsView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/ViewAppealDetailsView.scala.html
@@ -44,7 +44,7 @@
             @messages("viewAppealDetails.penaltyAppealed")
           </dt>
           <dd class="govuk-summary-list__value">
-              Late payment penalty: @DateFormatter.dateNonBreakingSpaceMultiple("2027", "2028") tax year
+              Late payment penalty: @DateFormatter.htmlNonBroken("2027 to 2028") tax year
           </dd>
         </div>
         <div class="govuk-summary-list__row" id="appealDate">
@@ -52,7 +52,7 @@
               @messages("viewAppealDetails.appealDate")
           </dt>
           <dd class="govuk-summary-list__value">
-             @DateFormatter.dateNonBreakingSpaceSingle("17 March 2029")
+             @DateFormatter.htmlNonBroken("17 March 2029")
           </dd>
         </div>
          @if(isAgent) {
@@ -86,7 +86,7 @@
             @messages(s"viewAppealDetails.$reasonableExcuseMessageKey.date.key")
             </dt>
             <dd class="govuk-summary-list__value">
-                @DateFormatter.dateNonBreakingSpaceSingle("20 January 2029")
+                @DateFormatter.htmlNonBroken("20 January 2029")
             </dd>
         </div>
         @if(reasonableExcuseMessageKey == "technicalIssues") {
@@ -95,7 +95,7 @@
                 @messages(s"viewAppealDetails.$reasonableExcuseMessageKey.date.end.key")
                 </dt>
                 <dd class="govuk-summary-list__value">
-                    @DateFormatter.dateNonBreakingSpaceSingle("20 February 2029")
+                    @DateFormatter.htmlNonBroken("20 February 2029")
                 </dd>
             </div>
         }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/WhatCausedYouToMissTheDeadlineView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/WhatCausedYouToMissTheDeadlineView.scala.html
@@ -21,15 +21,17 @@
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.ErrorSummaryViewModel
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.Layout
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 
 @this(layout: Layout,
-      govukButton : GovukButton,
-      govukErrorSummary: GovukErrorSummary,
-      formHelper: FormWithCSRF,
-      govukRadios : GovukRadios)
+        govukButton : GovukButton,
+        govukErrorSummary: GovukErrorSummary,
+        formHelper: FormWithCSRF,
+        govukRadios : GovukRadios,
+        caption: components.PenaltyCaption)
 
-@(form: Form[_], isLate: Boolean, isAgent: Boolean)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], isLate: Boolean, isAgent: Boolean)(implicit request: CurrentUserRequestWithAnswers[_], messages: Messages)
 
 @layout(Some(titleBuilder(messages("agents.whatCausedYouToMissTheDeadline.headingAndTitle"), Some(form))), backLinkEnabled = true) {
 
@@ -39,24 +41,24 @@
 
     @formHelper(action = uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.routes.WhatCausedYouToMissDeadlineController.submit()) {
 
-        <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption") @DateFormatter.dateNonBreakingSpaceMultiple("6 July 2027", "5 October 2027")</span>
+        @caption()
 
         @govukRadios(Radios(
             fieldset = Some(Fieldset(
-              legend = Some(Legend(
-                content = Text(messages("agents.whatCausedYouToMissTheDeadline.headingAndTitle")),
-                classes = "govuk-fieldset__legend--l",
-                isPageHeading = true
-              ))
+                legend = Some(Legend(
+                    content = Text(messages("agents.whatCausedYouToMissTheDeadline.headingAndTitle")),
+                    classes = "govuk-fieldset__legend--l",
+                    isPageHeading = true
+                ))
             )),
             name = WhatCausedYouToMissDeadlineForm.key,
             items = AgentClientEnum.radioOptions("whatCausedYouToMissTheDeadline")
         ).withFormField(form(WhatCausedYouToMissDeadlineForm.key)))
 
         <div class="govuk-form-group">
-            @govukButton(Button(
-                content = Text(messages("common.continue"))
-            ))
+        @govukButton(Button(
+            content = Text(messages("common.continue"))
+        ))
         </div>
     }
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/WhenDidEventEndView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/WhenDidEventEndView.scala.html
@@ -16,21 +16,20 @@
 
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.Layout
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components.inputDate
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.{Layout, components}
 
 @import java.time.LocalDate
-
 
 @this(layout: Layout,
         formHelper: FormWithCSRF,
         govukButton: GovukButton,
-        dateInput: inputDate,
-        govukErrorSummary: GovukErrorSummary)
+        govukErrorSummary: GovukErrorSummary,
+        dateInput: components.inputDate,
+        caption: components.PenaltyCaption)
 
-@(isAgent: Boolean, reasonableExcuseMessageKey: String,  form: Form[LocalDate])(implicit request: Request[_], messages: Messages)
+@(isAgent: Boolean, reasonableExcuseMessageKey: String,  form: Form[LocalDate])(implicit request: CurrentUserRequestWithAnswers[_], messages: Messages)
 
 @layout(Some(titleBuilder(messages(s"whenDidEventEnd.$reasonableExcuseMessageKey.headingAndTitle"), Some(form))), backLinkEnabled = true) {
 
@@ -40,7 +39,7 @@
 
     @formHelper(action = uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.routes.WhenDidEventEndController.submit()) {
 
-        <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption") @DateFormatter.dateNonBreakingSpaceMultiple("6 July 2027", "5 October 2027")</span>
+        @caption()
 
         @dateInput(
             form = form,

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/WhenDidEventHappenView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/WhenDidEventHappenView.scala.html
@@ -16,20 +16,20 @@
 
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichErrorSummary
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.Layout
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components.inputDate
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter
-@import java.time.LocalDate
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.helpers.WhenDidEventHappenHelper._
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.helpers.WhenDidEventHappenHelper._
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.{Layout, components}
+
+@import java.time.LocalDate
 
 @this(layout: Layout,
-      formHelper: FormWithCSRF,
-      govukButton : GovukButton,
-      govukDateInput : GovukDateInput,
-      govukErrorSummary: GovukErrorSummary,
-      dateInput: inputDate)
+        formHelper: FormWithCSRF,
+        govukButton : GovukButton,
+        govukDateInput : GovukDateInput,
+        govukErrorSummary: GovukErrorSummary,
+        dateInput: components.inputDate,
+        caption: components.PenaltyCaption)
 
 @(reasonableExcuseMessageKey: String, form: Form[LocalDate], isLPP: Boolean)(implicit user: CurrentUserRequestWithAnswers[_], messages: Messages)
 
@@ -39,22 +39,22 @@
         @govukErrorSummary(ErrorSummary().withFormErrorsAsText(form))
     }
 
- @formHelper(action = uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.routes.WhenDidEventHappenController.submit()) {
+    @formHelper(action = uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.routes.WhenDidEventHappenController.submit()) {
 
-     <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption") @DateFormatter.dateNonBreakingSpaceMultiple("6 July 2027", "5 October 2027")</span>
+        @caption()
 
-     @dateInput(
-         form = form,
-         legendContent = messages(s"${messageKeyPrefix(reasonableExcuseMessageKey, isLPP)}.headingAndTitle"),
-         legendClasses = Some("govuk-fieldset__legend--l"),
-         hintText = Some(messages("common.dateHint"))
-     )
+        @dateInput(
+            form = form,
+            legendContent = messages(s"${messageKeyPrefix(reasonableExcuseMessageKey, isLPP)}.headingAndTitle"),
+            legendClasses = Some("govuk-fieldset__legend--l"),
+            hintText = Some(messages("common.dateHint"))
+        )
 
-     <div class="govuk-form-group">
-       @govukButton(Button(
-        content = Text(messages("common.continue"))
-       ))
-     </div>
- }
+        <div class="govuk-form-group">
+            @govukButton(Button(
+                content = Text(messages("common.continue"))
+            ))
+        </div>
+    }
 
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/WhoPlannedToSubmitView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/WhoPlannedToSubmitView.scala.html
@@ -17,21 +17,21 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits._
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.WhoPlannedToSubmitForm
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.AgentClientEnum
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{AgentClientEnum, CurrentUserRequestWithAnswers}
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.ErrorSummaryViewModel
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.Layout
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.{Layout, components}
 
 @this(
         layout: Layout,
         govukButton : GovukButton,
         govukErrorSummary: GovukErrorSummary,
         formHelper: FormWithCSRF,
-        govukRadios : GovukRadios
+        govukRadios : GovukRadios,
+        caption: components.PenaltyCaption
 )
 
-@(form: Form[_], isLate: Boolean, isAgent: Boolean)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], isLate: Boolean, isAgent: Boolean)(implicit request: CurrentUserRequestWithAnswers[_], messages: Messages)
 
 @layout(Some(titleBuilder(messages("agents.whoPlannedToSubmit.headingAndTitle"), Some(form))), backLinkEnabled = true) {
 
@@ -41,7 +41,7 @@
 
     @formHelper(action = uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.routes.WhoPlannedToSubmitController.submit()) {
 
-        <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption") @DateFormatter.dateNonBreakingSpaceMultiple("6 July 2027", "5 October 2027")</span>
+        @caption()
 
         @govukRadios(Radios(
             fieldset = Some(Fieldset(

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/components/PenaltyCaption.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/components/PenaltyCaption.scala.html
@@ -23,6 +23,6 @@
 
 <span class="govuk-caption-l" id="captionSpan">
   @defining(if(user.isLPP) "service.lpp.caption" else "service.lsp.caption") { messageKey =>
-    @messages(messageKey, dateNonBreakingSpaceMultiple(dateToString(user.periodStartDate), dateToString(user.periodEndDate)))
+    @messages(messageKey, dateToString(user.periodStartDate), dateToString(user.periodEndDate))
   }
 </span>

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/components/PenaltyCaption.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/components/PenaltyCaption.scala.html
@@ -1,0 +1,28 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter._
+
+@this()
+
+@()(implicit messages: Messages, user: CurrentUserRequestWithAnswers[_])
+
+<span class="govuk-caption-l" id="captionSpan">
+  @defining(if(user.isLPP) "service.lpp.caption" else "service.lsp.caption") { messageKey =>
+    @messages(messageKey, dateNonBreakingSpaceMultiple(dateToString(user.periodStartDate), dateToString(user.periodEndDate)))
+  }
+</span>

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsFileUploadView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsFileUploadView.scala.html
@@ -17,11 +17,11 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan.UploadDocumentForm
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.UploadFormFields
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.ErrorSummaryViewModel
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.{Layout, components}
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter
 
 @this(
         layout: Layout,
@@ -32,10 +32,11 @@
         h1: components.H1,
         link: components.Link,
         bullets: components.Bullets,
-        details: components.Details
+        details: components.Details,
+        caption: components.PenaltyCaption
 )
 
-@(form: Form[_], upscanFormFields: UploadFormFields)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(form: Form[_], upscanFormFields: UploadFormFields)(implicit request: CurrentUserRequestWithAnswers[_], messages: Messages, appConfig: AppConfig)
 
 @supportedFileTypes = {
     @p(messages("uploadEvidence.typesOfFile.p1"))
@@ -56,7 +57,7 @@
         @govukErrorSummary(ErrorSummaryViewModel(form))
     }
 
-    <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption") @DateFormatter.dateNonBreakingSpaceMultiple("6 July 2027", "5 October 2027")</span>
+    @caption()
     @h1("uploadEvidence.nonJs.headingAndTitle")
 
     <p class="govuk-body">@messages("uploadEvidence.nonJs.p1")</p>

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsRemoveFileView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsRemoveFileView.scala.html
@@ -17,21 +17,22 @@
 @import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan.UploadRemoveFileForm
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.{ErrorSummaryViewModel, UploadedFilesViewModel}
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils._
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.helpers.YesNoRadioHelper
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.Layout
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.{Layout, components}
 
 @this(
         layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukRadios: GovukRadios,
-        govukButton: GovukButton
+        govukButton: GovukButton,
+        caption: components.PenaltyCaption
 )
 
-@(form: Form[_], file: UploadedFilesViewModel, postAction: Call)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], file: UploadedFilesViewModel, postAction: Call)(implicit request: CurrentUserRequestWithAnswers[_], messages: Messages)
 
 @layout(pageTitle = Some(titleBuilder(messages("uploadRemoveFile.nonJs.headingAndTitle", file.index), Some(form)))) {
 
@@ -39,7 +40,7 @@
         @govukErrorSummary(ErrorSummaryViewModel(form))
     }
 
-    <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption") @DateFormatter.dateNonBreakingSpaceMultiple("6 July 2027", "5 October 2027")</span>
+    @caption()
 
     @formHelper(action = postAction) {
 

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsUploadCheckAnswersView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsUploadCheckAnswersView.scala.html
@@ -14,15 +14,15 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan.UploadAnotherFileForm
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.{ErrorSummaryViewModel, UploadedFilesViewModel}
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils._
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.{Layout, components}
-@import uk.gov.hmrc.govukfrontend.views.Implicits.RichRadios
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan.UploadAnotherFileForm
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.helpers.YesNoRadioHelper
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.{Layout, components}
 
 @this(
         layout: Layout,
@@ -32,10 +32,11 @@
         govukButton: GovukButton,
         p: components.P,
         h1: components.H1,
+        caption: components.PenaltyCaption,
         govukSummaryList: GovukSummaryList
 )
 
-@(form: Form[_], uploadedFiles: Seq[UploadedFilesViewModel], postAction: Call)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(form: Form[_], uploadedFiles: Seq[UploadedFilesViewModel], postAction: Call)(implicit request: CurrentUserRequestWithAnswers[_], messages: Messages, appConfig: AppConfig)
 
 @layout(pageTitle = Some(titleBuilder(messages(pluralOrSingular("uploadCheckAnswers.nonJs.headingAndTitle", uploadedFiles), uploadedFiles.size), Some(form)))) {
 
@@ -43,7 +44,7 @@
         @govukErrorSummary(ErrorSummaryViewModel(form))
     }
 
-    <span class="govuk-caption-l" id="captionSpan">@messages("appeal.start.caption") @DateFormatter.dateNonBreakingSpaceMultiple("6 July 2027", "5 October 2027")</span>
+    @caption()
     @h1(pluralOrSingular("uploadCheckAnswers.nonJs.headingAndTitle", uploadedFiles), args = Seq(uploadedFiles.size))
 
     @govukSummaryList(SummaryList(

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -11,7 +11,7 @@ GET        /language/:lang                  uk.gov.hmrc.incometaxpenaltiesappeal
 
 #Initialise appeal and start page
 GET        /appeal-start                    uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.AppealStartController.onPageLoad()
-GET        /initialise-appeal               uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.InitialisationController.onPageLoad(penaltyId: String)
+GET        /initialise-appeal               uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.InitialisationController.onPageLoad(penaltyId: String, isLPP: Boolean, isAdditional: Boolean)
 
 #Reasonable excuse list
 GET        /reason-for-missing-deadline     uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.ReasonableExcuseController.onPageLoad()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -112,11 +112,6 @@ play.i18n.langCookieHttpOnly: "true"
 
 play.i18n.langs = ["en", "cy"]
 
-constants {
-  daysRequiredForLateAppeal = 30
-  numberOfCharsInTextArea = 5000
-}
-
 signIn {
   url = "http://localhost:9949/auth-login-stub/gg-sign-in"
   continueBaseUrl = "http://localhost:9188"

--- a/conf/messages
+++ b/conf/messages
@@ -5,8 +5,11 @@ error.title.prefix = Error:
 govuk.suffix = GOV.UK
 alphaBanner.message = This is a new service – your {0} will help us to improve it.
 alphaBanner.linkText = feedback
+
 date.from.to = {0} to {1}
-appeal.start.caption = Late submission penalty point:
+service.lsp.caption = Late submission penalty point: {0}
+service.lpp.caption = Late payment penalty: {0}
+
 appeal.start.header = Appeal a Self Assessment penalty
 appeal.start.p1 = To appeal a late submission penalty for Self Assessment, you’ll need to ask HMRC to look at your case again.
 appeal.start.p2 = This service is for appealing penalties given for individual submissions.

--- a/conf/messages
+++ b/conf/messages
@@ -6,9 +6,8 @@ govuk.suffix = GOV.UK
 alphaBanner.message = This is a new service – your {0} will help us to improve it.
 alphaBanner.linkText = feedback
 
-date.from.to = {0} to {1}
-service.lsp.caption = Late submission penalty point: {0}
-service.lpp.caption = Late payment penalty: {0}
+service.lsp.caption = Late submission penalty point: {0} to {1}
+service.lpp.caption = Late payment penalty: {0} to {1}
 
 appeal.start.header = Appeal a Self Assessment penalty
 appeal.start.p1 = To appeal a late submission penalty for Self Assessment, you’ll need to ask HMRC to look at your case again.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -6,10 +6,8 @@ govuk.suffix = GOV.UK
 alphaBanner.message = This is a new service – your {0} will help us to improve it. (Welsh)
 alphaBanner.linkText = feedback (Welsh)
 
-date.from.to = {0} i {1}
-
-service.lsp.caption = Late submission penalty point: {0} (Welsh)
-service.lpp.caption = Late payment penalty: {0} (Welsh)
+service.lsp.caption = Late submission penalty point: {0} to {1} (Welsh)
+service.lpp.caption = Late payment penalty: {0} to {1} (Welsh)
 
 appeal.start.header = Appeal a Self Assessment penalty (Welsh)
 appeal.start.p1 = To appeal a late submission penalty for Self Assessment, you’ll need to ask HMRC to look at your case again. (Welsh)

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -5,8 +5,12 @@ error.title.prefix = Gwall:
 govuk.suffix = GOV.UK
 alphaBanner.message = This is a new service – your {0} will help us to improve it. (Welsh)
 alphaBanner.linkText = feedback (Welsh)
+
 date.from.to = {0} i {1}
-appeal.start.caption = Late submission penalty point: (Welsh)
+
+service.lsp.caption = Late submission penalty point: {0} (Welsh)
+service.lpp.caption = Late payment penalty: {0} (Welsh)
+
 appeal.start.header = Appeal a Self Assessment penalty (Welsh)
 appeal.start.p1 = To appeal a late submission penalty for Self Assessment, you’ll need to ask HMRC to look at your case again. (Welsh)
 appeal.start.p2 = This service is for appealing penalties given for individual submissions. (Welsh)

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/AppealStartControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/AppealStartControllerISpec.scala
@@ -16,16 +16,22 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
+import fixtures.messages.English
 import org.jsoup.Jsoup
 import play.api.http.Status.OK
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 
 class AppealStartControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(En.code)))
 
   "GET /appeal-start" should {
 
@@ -55,7 +61,10 @@ class AppealStartControllerISpec extends ComponentSpecHelper with ViewSpecHelper
 
         document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
         document.title() shouldBe "Appeal a Self Assessment penalty - Appeal a Self Assessment penalty - GOV.UK"
-        document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+        document.getElementById("captionSpan").text() shouldBe English.lspCaption(
+          dateToString(lateSubmissionAppealData.startDate),
+          dateToString(lateSubmissionAppealData.endDate)
+        )
         document.getH1Elements.text() shouldBe "Appeal a Self Assessment penalty"
         document.getParagraphs.get(0).text() shouldBe "To appeal a late submission penalty for Self Assessment, you’ll need to ask HMRC to look at your case again."
         document.getParagraphs.get(1).text() shouldBe "This service is for appealing penalties given for individual submissions."
@@ -79,7 +88,10 @@ class AppealStartControllerISpec extends ComponentSpecHelper with ViewSpecHelper
 
         document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
         document.title() shouldBe "Appeal a Self Assessment penalty - Appeal a Self Assessment penalty - GOV.UK"
-        document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+        document.getElementById("captionSpan").text() shouldBe English.lspCaption(
+          dateToString(lateSubmissionAppealData.startDate),
+          dateToString(lateSubmissionAppealData.endDate)
+        )
         document.getH1Elements.text() shouldBe "Appeal a Self Assessment penalty"
         document.getParagraphs.get(0).text() shouldBe "To appeal a late submission penalty for Self Assessment, you’ll need to ask HMRC to look at your case again."
         document.getParagraphs.get(1).text() shouldBe "This service is for appealing penalties given for individual submissions."

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CheckYourAnswersControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CheckYourAnswersControllerISpec.scala
@@ -16,18 +16,21 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
-import fixtures.messages.ReasonableExcuseMessages
+import fixtures.messages.{English, ReasonableExcuseMessages}
 import fixtures.views.BaseSelectors
 import org.jsoup.Jsoup
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK, SEE_OTHER}
+import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.api.libs.json.Json
 import play.api.test.Helpers.LOCATION
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.featureswitch.core.config.UseStubForBackend
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{HonestyDeclarationPage, ReasonableExcusePage, WhenDidEventHappenPage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.{AuthStub, PenaltiesStub}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 import java.time.LocalDate
@@ -36,6 +39,9 @@ class CheckYourAnswersControllerISpec extends ComponentSpecHelper with ViewSpecH
   with AuthStub with NavBarTesterHelper with PenaltiesStub {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(En.code)))
+
   val errorHandler = app.injector.instanceOf[ErrorHandler]
 
   lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
@@ -102,7 +108,10 @@ class CheckYourAnswersControllerISpec extends ComponentSpecHelper with ViewSpecH
 
           document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
           document.title() shouldBe "Check your answers - Appeal a Self Assessment penalty - GOV.UK"
-          document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+          document.getElementById("captionSpan").text() shouldBe English.lspCaption(
+            dateToString(lateSubmissionAppealData.startDate),
+            dateToString(lateSubmissionAppealData.endDate)
+          )
           document.getH1Elements.text() shouldBe "Check your answers"
           document.select(Selectors.h2(1)).text() shouldBe "Appeal details"
           document.select(Selectors.summaryRowKey(1)).text() shouldBe ReasonableExcuseMessages.English.cyaKey
@@ -123,7 +132,10 @@ class CheckYourAnswersControllerISpec extends ComponentSpecHelper with ViewSpecH
 
           document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
           document.title() shouldBe "Check your answers - Appeal a Self Assessment penalty - GOV.UK"
-          document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+          document.getElementById("captionSpan").text() shouldBe English.lspCaption(
+            dateToString(lateSubmissionAppealData.startDate),
+            dateToString(lateSubmissionAppealData.endDate)
+          )
           document.getH1Elements.text() shouldBe "Check your answers"
           document.select(Selectors.h2(1)).text() shouldBe "Appeal details"
           document.select(Selectors.summaryRowKey(1)).text() shouldBe ReasonableExcuseMessages.English.cyaKey

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CheckYourAnswersControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CheckYourAnswersControllerISpec.scala
@@ -25,11 +25,10 @@ import play.api.libs.json.Json
 import play.api.test.Helpers.LOCATION
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.featureswitch.core.config.UseStubForBackend
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{HonestyDeclarationPage, ReasonableExcusePage, WhenDidEventHappenPage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.{AuthStub, PenaltiesStub}
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, IncomeTaxSessionKeys, NavBarTesterHelper, ViewSpecHelper}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 import java.time.LocalDate
 
@@ -64,7 +63,7 @@ class CheckYourAnswersControllerISpec extends ComponentSpecHelper with ViewSpecH
 
   for (reason <- reasonsList) {
 
-    val userAnswersWithReason = UserAnswers(testJourneyId).setAnswer(ReasonableExcusePage, reason)
+    val userAnswersWithReason = emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, reason)
 
     s"GET /check-your-answers with reasonableExcuse='$reason'" should {
 
@@ -143,8 +142,7 @@ class CheckYourAnswersControllerISpec extends ComponentSpecHelper with ViewSpecH
       "the Appeals Submission model can be constructed successfully" when {
 
         lazy val userAnswers =
-          UserAnswers(testJourneyId)
-            .setAnswerForKey[String](IncomeTaxSessionKeys.penaltyNumber, "1")
+          emptyUerAnswersWithLSP
             .setAnswer(ReasonableExcusePage, "fireOrFlood")
             .setAnswer(HonestyDeclarationPage, true)
             .setAnswer(WhenDidEventHappenPage, LocalDate.of(2024, 1, 1))
@@ -154,7 +152,7 @@ class CheckYourAnswersControllerISpec extends ComponentSpecHelper with ViewSpecH
             stubAuth(OK, successfulIndividualAuthResponse)
             userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
-            successfulAppealSubmission(testMtdItId, isLPP = false, "1")
+            successfulAppealSubmission(testMtdItId, isLPP = false, penaltyDataLSP.penaltyNumber)
 
             val result = post("/check-your-answers")(Json.obj())
 
@@ -181,8 +179,7 @@ class CheckYourAnswersControllerISpec extends ComponentSpecHelper with ViewSpecH
       "the Appeals Submission model can NOT be constructed successfully" when {
 
         lazy val userAnswers =
-          UserAnswers(testJourneyId)
-            .setAnswerForKey[String](IncomeTaxSessionKeys.penaltyNumber, "1")
+          emptyUerAnswersWithLSP
             .setAnswer(HonestyDeclarationPage, true)
             .setAnswer(WhenDidEventHappenPage, LocalDate.of(2024, 1, 1))
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CheckYourAnswersControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CheckYourAnswersControllerISpec.scala
@@ -166,7 +166,7 @@ class CheckYourAnswersControllerISpec extends ComponentSpecHelper with ViewSpecH
             stubAuth(OK, successfulIndividualAuthResponse)
             userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
-            failedAppealSubmission(testMtdItId, isLPP = false, "1")
+            failedAppealSubmission(testMtdItId, isLPP = false, penaltyDataLSP.penaltyNumber)
 
             val result = post("/check-your-answers")(Json.obj())
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ConfirmationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ConfirmationControllerISpec.scala
@@ -20,7 +20,6 @@ import org.jsoup.Jsoup
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.OK
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.ReasonableExcusePage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
@@ -34,7 +33,7 @@ class ConfirmationControllerISpec extends ComponentSpecHelper with ViewSpecHelpe
 
   override def beforeEach(): Unit = {
     deleteAll(userAnswersRepo)
-    userAnswersRepo.upsertUserAnswer(UserAnswers(testJourneyId).setAnswer(ReasonableExcusePage, "defaultReason")).futureValue
+    userAnswersRepo.upsertUserAnswer(emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, "defaultReason")).futureValue
     super.beforeEach()
   }
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CrimeReportedControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CrimeReportedControllerISpec.scala
@@ -36,7 +36,7 @@ class CrimeReportedControllerISpec extends ComponentSpecHelper with ViewSpecHelp
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
 
-  val crimeAnswers: UserAnswers = UserAnswers(testJourneyId).setAnswer(ReasonableExcusePage, "crime")
+  val crimeAnswers: UserAnswers = emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, "crime")
 
   override def beforeEach(): Unit = {
     userAnswersRepo.collection.deleteMany(Document()).toFuture().futureValue

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CrimeReportedControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/CrimeReportedControllerISpec.scala
@@ -21,6 +21,8 @@ import org.jsoup.Jsoup
 import org.mongodb.scala.Document
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.CrimeReportedForm
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CrimeReportedEnum
@@ -28,6 +30,7 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{CrimeReportedPage, ReasonableExcusePage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 class CrimeReportedControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
@@ -35,6 +38,8 @@ class CrimeReportedControllerISpec extends ComponentSpecHelper with ViewSpecHelp
   lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(En.code)))
 
   val crimeAnswers: UserAnswers = emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, "crime")
 
@@ -84,7 +89,10 @@ class CrimeReportedControllerISpec extends ComponentSpecHelper with ViewSpecHelp
 
         document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
         document.title() shouldBe "Has this crime been reported to the police? - Appeal a Self Assessment penalty - GOV.UK"
-        document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+        document.getElementById("captionSpan").text() shouldBe CrimeReportedMessages.English.lspCaption(
+          dateToString(lateSubmissionAppealData.startDate),
+          dateToString(lateSubmissionAppealData.endDate)
+        )
         document.getH1Elements.text() shouldBe "Has this crime been reported to the police?"
         document.getElementsByAttributeValue("for", s"${CrimeReportedForm.key}").text() shouldBe CrimeReportedMessages.English.yes
         document.getElementsByAttributeValue("for", s"${CrimeReportedForm.key}-2").text() shouldBe CrimeReportedMessages.English.no
@@ -99,7 +107,10 @@ class CrimeReportedControllerISpec extends ComponentSpecHelper with ViewSpecHelp
 
         document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
         document.title() shouldBe "Has this crime been reported to the police? - Appeal a Self Assessment penalty - GOV.UK"
-        document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+        document.getElementById("captionSpan").text() shouldBe CrimeReportedMessages.English.lspCaption(
+          dateToString(lateSubmissionAppealData.startDate),
+          dateToString(lateSubmissionAppealData.endDate)
+        )
         document.getH1Elements.text() shouldBe "Has this crime been reported to the police?"
         document.getElementsByAttributeValue("for", s"${CrimeReportedForm.key}").text() shouldBe CrimeReportedMessages.English.yes
         document.getElementsByAttributeValue("for", s"${CrimeReportedForm.key}-2").text() shouldBe CrimeReportedMessages.English.no

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ExtraEvidenceControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ExtraEvidenceControllerISpec.scala
@@ -21,6 +21,8 @@ import org.jsoup.Jsoup
 import org.mongodb.scala.Document
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.ExtraEvidenceForm
@@ -28,6 +30,7 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{ExtraEvidencePage, ReasonableExcusePage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 class ExtraEvidenceControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
@@ -35,6 +38,8 @@ class ExtraEvidenceControllerISpec extends ComponentSpecHelper with ViewSpecHelp
   lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(En.code)))
 
   val otherAnswers: UserAnswers = emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, "other")
 
@@ -82,7 +87,10 @@ class ExtraEvidenceControllerISpec extends ComponentSpecHelper with ViewSpecHelp
 
         document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
         document.title() shouldBe "Do you want to upload evidence to support your appeal? - Appeal a Self Assessment penalty - GOV.UK"
-        document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+        document.getElementById("captionSpan").text() shouldBe ExtraEvidenceMessages.English.lspCaption(
+          dateToString(lateSubmissionAppealData.startDate),
+          dateToString(lateSubmissionAppealData.endDate)
+        )
         document.getH1Elements.text() shouldBe "Do you want to upload evidence to support your appeal?"
         document.getElementById("extraEvidence-hint").text() shouldBe "Uploading evidence is optional. We will still review this appeal if you do not upload evidence."
         document.getElementsByAttributeValue("for", s"${ExtraEvidenceForm.key}").text() shouldBe ExtraEvidenceMessages.English.yes
@@ -98,7 +106,10 @@ class ExtraEvidenceControllerISpec extends ComponentSpecHelper with ViewSpecHelp
 
         document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
         document.title() shouldBe "Do you want to upload evidence to support your appeal? - Appeal a Self Assessment penalty - GOV.UK"
-        document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+        document.getElementById("captionSpan").text() shouldBe ExtraEvidenceMessages.English.lspCaption(
+          dateToString(lateSubmissionAppealData.startDate),
+          dateToString(lateSubmissionAppealData.endDate)
+        )
         document.getH1Elements.text() shouldBe "Do you want to upload evidence to support your appeal?"
         document.getElementById("extraEvidence-hint").text() shouldBe "Uploading evidence is optional. We will still review this appeal if you do not upload evidence."
         document.getElementsByAttributeValue("for", s"${ExtraEvidenceForm.key}").text() shouldBe ExtraEvidenceMessages.English.yes

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ExtraEvidenceControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ExtraEvidenceControllerISpec.scala
@@ -26,35 +26,48 @@ import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.ExtraEvidenceForm
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.PenaltyData
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{ExtraEvidencePage, ReasonableExcusePage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, IncomeTaxSessionKeys, NavBarTesterHelper, TimeMachine, ViewSpecHelper}
 
 class ExtraEvidenceControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
 
   lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit lazy val timeMachine: TimeMachine = app.injector.instanceOf[TimeMachine]
   implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
   implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(En.code)))
 
-  val otherAnswers: UserAnswers = emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, "other")
+  class Setup(isLate: Boolean = false) {
 
-  override def beforeEach(): Unit = {
     userAnswersRepo.collection.deleteMany(Document()).toFuture().futureValue
+
+    val otherAnswers: UserAnswers = emptyUserAnswers
+      .setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyDataLSP.copy(
+        appealData = lateSubmissionAppealData.copy(
+          dateCommunicationSent =
+            if (isLate) timeMachine.getCurrentDate.minusDays(appConfig.lateDays + 1)
+            else        timeMachine.getCurrentDate.minusDays(1)
+        )
+      ))
+      .setAnswer(ReasonableExcusePage, "other")
+
     userAnswersRepo.upsertUserAnswer(otherAnswers).futureValue
-    super.beforeEach()
   }
 
   "GET /upload-extra-evidence" should {
 
-    testNavBar(url = "/upload-extra-evidence")()
+    testNavBar(url = "/upload-extra-evidence")(
+      userAnswersRepo.upsertUserAnswer(emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, "other")).futureValue
+    )
 
     "return an OK with a view" when {
-      "the user is an authorised individual AND the page has already been answered" in {
+      "the user is an authorised individual AND the page has already been answered" in new Setup() {
         stubAuth(OK, successfulIndividualAuthResponse)
         userAnswersRepo.upsertUserAnswer(otherAnswers.setAnswer(ExtraEvidencePage, true)).futureValue
 
@@ -66,7 +79,7 @@ class ExtraEvidenceControllerISpec extends ComponentSpecHelper with ViewSpecHelp
         document.select(s"#${ExtraEvidenceForm.key}-2").hasAttr("checked") shouldBe false
       }
 
-      "the user is an authorised agent AND page NOT already answered" in {
+      "the user is an authorised agent AND page NOT already answered" in new Setup() {
         stubAuth(OK, successfulAgentAuthResponse)
 
         val result = get("/upload-extra-evidence", isAgent = true)
@@ -79,7 +92,7 @@ class ExtraEvidenceControllerISpec extends ComponentSpecHelper with ViewSpecHelp
     }
 
     "the page has the correct elements" when {
-      "the user is an authorised individual" in {
+      "the user is an authorised individual" in new Setup() {
         stubAuth(OK, successfulIndividualAuthResponse)
         val result = get("/upload-extra-evidence")
 
@@ -98,7 +111,7 @@ class ExtraEvidenceControllerISpec extends ComponentSpecHelper with ViewSpecHelp
         document.getSubmitButton.text() shouldBe "Continue"
       }
 
-      "the user is an authorised agent" in {
+      "the user is an authorised agent" in new Setup() {
         stubAuth(OK, successfulAgentAuthResponse)
         val result = get("/upload-extra-evidence", isAgent = true)
 
@@ -124,7 +137,7 @@ class ExtraEvidenceControllerISpec extends ComponentSpecHelper with ViewSpecHelp
 
     "the radio option posted is valid" should {
 
-      "save the value to UserAnswers AND redirect to the UpscanCheckAnswers page if the answer is 'Yes'" in {
+      "save the value to UserAnswers AND redirect to the UpscanCheckAnswers page if the answer is 'Yes'" in new Setup() {
 
         stubAuth(OK, successfulIndividualAuthResponse)
 
@@ -136,22 +149,43 @@ class ExtraEvidenceControllerISpec extends ComponentSpecHelper with ViewSpecHelp
         userAnswersRepo.getUserAnswer(testJourneyId).futureValue.flatMap(_.getAnswer(ExtraEvidencePage)) shouldBe Some(true)
       }
 
-      "save the value to UserAnswers AND redirect to the LateAppeal page if the answer is 'No'" in {
+      "save the value to UserAnswers AND redirect the answer is 'No'" when {
 
-        stubAuth(OK, successfulIndividualAuthResponse)
+        "appeal is Late" should {
 
-        val result = post("/upload-extra-evidence")(Map(ExtraEvidenceForm.key -> false))
+          "redirect to the LateAppeal page" in new Setup(isLate = true) {
 
-        result.status shouldBe SEE_OTHER
-        result.header("Location") shouldBe Some(routes.LateAppealController.onPageLoad().url)
+            stubAuth(OK, successfulIndividualAuthResponse)
 
-        userAnswersRepo.getUserAnswer(testJourneyId).futureValue.flatMap(_.getAnswer(ExtraEvidencePage)) shouldBe Some(false)
+            val result = post("/upload-extra-evidence")(Map(ExtraEvidenceForm.key -> false))
+
+            result.status shouldBe SEE_OTHER
+            result.header("Location") shouldBe Some(routes.LateAppealController.onPageLoad().url)
+
+            userAnswersRepo.getUserAnswer(testJourneyId).futureValue.flatMap(_.getAnswer(ExtraEvidencePage)) shouldBe Some(false)
+          }
+        }
+
+        "appeal is NOT Late" should {
+
+          "redirect to the CheckAnswers page" in new Setup() {
+
+            stubAuth(OK, successfulIndividualAuthResponse)
+
+            val result = post("/upload-extra-evidence")(Map(ExtraEvidenceForm.key -> false))
+
+            result.status shouldBe SEE_OTHER
+            result.header("Location") shouldBe Some(routes.CheckYourAnswersController.onPageLoad().url)
+
+            userAnswersRepo.getUserAnswer(testJourneyId).futureValue.flatMap(_.getAnswer(ExtraEvidencePage)) shouldBe Some(false)
+          }
+        }
       }
     }
 
     "the radio option is invalid" should {
 
-      "render a bad request with the Form Error on the page with a link to the field in error" in {
+      "render a bad request with the Form Error on the page with a link to the field in error" in new Setup() {
 
         stubAuth(OK, successfulIndividualAuthResponse)
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ExtraEvidenceControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ExtraEvidenceControllerISpec.scala
@@ -36,7 +36,7 @@ class ExtraEvidenceControllerISpec extends ComponentSpecHelper with ViewSpecHelp
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
 
-  val otherAnswers: UserAnswers = UserAnswers(testJourneyId).setAnswer(ReasonableExcusePage, "other")
+  val otherAnswers: UserAnswers = emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, "other")
 
   override def beforeEach(): Unit = {
     userAnswersRepo.collection.deleteMany(Document()).toFuture().futureValue

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/HonestyDeclarationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/HonestyDeclarationControllerISpec.scala
@@ -16,31 +16,39 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
+import fixtures.messages.English
 import org.jsoup.Jsoup
 import org.mongodb.scala.Document
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.{OK, SEE_OTHER}
+import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.api.libs.json.Json
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{HonestyDeclarationPage, ReasonableExcusePage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 class HonestyDeclarationControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(En.code)))
 
   lazy val userAnswersRepo = app.injector.instanceOf[UserAnswersRepository]
 
-  val bereavementMessage: String = "because I was affected by someone’s death, I was unable to send the submission due on 5 November 2027"
-  val cessationMessage: String = "TBC cessation - I was unable to send the submission due on 5 November 2027"
-  val crimeMessage: String = "because I was affected by a crime, I was unable to send the submission due on 5 November 2027"
-  val fireOrFloodReasonMessage: String = "because of a fire or flood, I was unable to send the submission due on 5 November 2027"
-  val healthMessage: String = "TBC health - I was unable to send the submission due on 5 November 2027"
-  val technicalIssueMessage: String = "because of software or technology issues, I was unable to send the submission due on 5 November 2027"
-  val unexpectedHospitalMessage: String = "TBC unexpectedHospital - I was unable to send the submission due on 5 November 2027"
-  val otherMessage: String = "TBC other - I was unable to send the submission due on 5 November 2027"
+  val dueDate = dateToString(lateSubmissionAppealData.dueDate).replace("\u00A0", " ")
+
+  val bereavementMessage: String = s"because I was affected by someone’s death, I was unable to send the submission due on $dueDate"
+  val cessationMessage: String = s"TBC cessation - I was unable to send the submission due on $dueDate"
+  val crimeMessage: String = s"because I was affected by a crime, I was unable to send the submission due on $dueDate"
+  val fireOrFloodReasonMessage: String = s"because of a fire or flood, I was unable to send the submission due on $dueDate"
+  val healthMessage: String = s"TBC health - I was unable to send the submission due on $dueDate"
+  val technicalIssueMessage: String = s"because of software or technology issues, I was unable to send the submission due on $dueDate"
+  val unexpectedHospitalMessage: String = s"TBC unexpectedHospital - I was unable to send the submission due on $dueDate"
+  val otherMessage: String = s"TBC other - I was unable to send the submission due on $dueDate"
 
   val reasonsList: List[(String, String)]= List(
     ("bereavement", bereavementMessage),
@@ -100,7 +108,10 @@ class HonestyDeclarationControllerISpec extends ComponentSpecHelper with ViewSpe
 
           document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
           document.title() shouldBe "Honesty declaration - Appeal a Self Assessment penalty - GOV.UK"
-          document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+          document.getElementById("captionSpan").text() shouldBe English.lspCaption(
+            dateToString(lateSubmissionAppealData.startDate),
+            dateToString(lateSubmissionAppealData.endDate)
+          )
           document.getH1Elements.text() shouldBe "Honesty declaration"
           document.getElementById("honestyDeclarationConfirm").text() shouldBe "I confirm that:"
           document.getElementById("honestyDeclarationReason").text() shouldBe reason._2
@@ -118,7 +129,10 @@ class HonestyDeclarationControllerISpec extends ComponentSpecHelper with ViewSpe
 
           document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
           document.title() shouldBe "Honesty declaration - Appeal a Self Assessment penalty - GOV.UK"
-          document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+          document.getElementById("captionSpan").text() shouldBe English.lspCaption(
+            dateToString(lateSubmissionAppealData.startDate),
+            dateToString(lateSubmissionAppealData.endDate)
+          )
           document.getH1Elements.text() shouldBe "Honesty declaration"
           document.getElementById("honestyDeclarationConfirm").text() shouldBe "I confirm that:"
           document.getElementById("honestyDeclarationReason").text() shouldBe reason._2

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationControllerISpec.scala
@@ -59,7 +59,7 @@ class InitialisationControllerISpec extends ComponentSpecHelper with ViewSpecHel
         "the user is an authorised individual" in {
 
           stubAuth(OK, successfulIndividualAuthResponse)
-          successfulGetAppealDataResponse(penaltyDataLSP.penaltyNumber, EnrolmentUtil.buildItsaEnrolment(testMtdItId))
+          successfulGetAppealDataResponse(penaltyDataLSP.penaltyNumber, testMtdItId)
 
           val result = get(s"/initialise-appeal?penaltyId=${penaltyDataLSP.penaltyNumber}&isLPP=false&isAdditional=false")
 
@@ -88,8 +88,8 @@ class InitialisationControllerISpec extends ComponentSpecHelper with ViewSpecHel
         "the user is an authorised agent (and LPP with multiple)" in {
 
           stubAuth(OK, successfulAgentAuthResponse)
-          successfulGetAppealDataResponse(penaltyDataLPP.penaltyNumber, EnrolmentUtil.buildItsaEnrolment(testMtdItId), isLPP = true)
-          successfulGetMultiplePenalties(penaltyDataLPP.penaltyNumber, EnrolmentUtil.buildItsaEnrolment(testMtdItId))
+          successfulGetAppealDataResponse(penaltyDataLPP.penaltyNumber, testMtdItId, isLPP = true)
+          successfulGetMultiplePenalties(penaltyDataLPP.penaltyNumber, testMtdItId)
 
           val result = get(s"/initialise-appeal?penaltyId=${penaltyDataLPP.penaltyNumber}&isLPP=true&isAdditional=false", isAgent = true)
 
@@ -129,7 +129,7 @@ class InitialisationControllerISpec extends ComponentSpecHelper with ViewSpecHel
       "render an ISE" in {
 
         stubAuth(OK, successfulIndividualAuthResponse)
-        failedGetAppealDataResponse(penaltyDataLSP.penaltyNumber, EnrolmentUtil.buildItsaEnrolment(testMtdItId))
+        failedGetAppealDataResponse(penaltyDataLSP.penaltyNumber, testMtdItId)
 
         val result = get(s"/initialise-appeal?penaltyId=${penaltyDataLSP.penaltyNumber}&isLPP=false&isAdditional=false")
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationControllerISpec.scala
@@ -17,19 +17,22 @@
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
-import play.api.http.Status.{OK, SEE_OTHER}
+import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK, SEE_OTHER}
 import play.api.libs.json.Json
 import play.api.{Application, inject}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.featureswitch.core.config.UseStubForBackend
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.PenaltyTypeEnum
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.{AuthStub, PenaltiesStub}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils._
 
 import java.time.temporal.ChronoUnit
-import java.time.{LocalDateTime, ZoneOffset}
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
 
-class InitialisationControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
+class InitialisationControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper
+  with PenaltiesStub {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
 
@@ -45,41 +48,92 @@ class InitialisationControllerISpec extends ComponentSpecHelper with ViewSpecHel
     inject.bind[TimeMachine].toInstance(timeMachine)
   )
 
-  "GET /initialise-appeal" should {
+  override def beforeEach(): Unit = {
+    disable(UseStubForBackend)
+    super.beforeEach()
+  }
 
-    "initialise the UserAnswers and redirect to the /appeal-start page, adding the journeyId to session" when {
-      "the user is an authorised individual" in {
-        stubAuth(OK, successfulIndividualAuthResponse)
-        val result = get("/initialise-appeal?penaltyId=1")
+  "GET /initialise-appeal" when {
+    "penalty appeal data is successfully returned from penalties BE" when {
+      "initialise the UserAnswers and redirect to the /appeal-start page, adding the journeyId to session" when {
+        "the user is an authorised individual" in {
 
-        result.status shouldBe SEE_OTHER
-        result.header("Location") shouldBe Some(routes.AppealStartController.onPageLoad().url)
-        SessionCookieCrumbler.getSessionMap(result).get(IncomeTaxSessionKeys.journeyId) shouldBe Some(testJourneyId)
+          stubAuth(OK, successfulIndividualAuthResponse)
+          successfulGetAppealDataResponse(penaltyDataLSP.penaltyNumber, EnrolmentUtil.buildItsaEnrolment(testMtdItId))
 
-        userAnswers.getUserAnswer(testJourneyId).futureValue shouldBe Some(UserAnswers(
-          journeyId = testJourneyId,
-          data = Json.obj(
-            IncomeTaxSessionKeys.penaltyNumber -> "1"
-          ),
-          lastUpdated = testDateTime.toInstant(ZoneOffset.UTC)
-        ))
+          val result = get(s"/initialise-appeal?penaltyId=${penaltyDataLSP.penaltyNumber}&isLPP=false&isAdditional=false")
+
+          result.status shouldBe SEE_OTHER
+          result.header("Location") shouldBe Some(routes.AppealStartController.onPageLoad().url)
+          SessionCookieCrumbler.getSessionMap(result).get(IncomeTaxSessionKeys.journeyId) shouldBe Some(testJourneyId)
+
+          userAnswers.getUserAnswer(testJourneyId).futureValue shouldBe Some(UserAnswers(
+            journeyId = testJourneyId,
+            data = Json.obj(
+              IncomeTaxSessionKeys.penaltyData -> Json.obj(
+                "penaltyNumber" -> penaltyDataLSP.penaltyNumber,
+                "appealData" -> Json.obj(
+                  "type" -> PenaltyTypeEnum.Late_Submission,
+                  "startDate" -> LocalDate.of(2020, 1, 1),
+                  "endDate" -> LocalDate.of(2020, 1, 31),
+                  "dueDate" -> LocalDate.of(2020, 3, 7),
+                  "dateCommunicationSent" -> LocalDate.of(2020, 3, 8)
+                )
+              )
+            ),
+            lastUpdated = testDateTime.toInstant(ZoneOffset.UTC)
+          ))
+        }
+
+        "the user is an authorised agent (and LPP with multiple)" in {
+
+          stubAuth(OK, successfulAgentAuthResponse)
+          successfulGetAppealDataResponse(penaltyDataLPP.penaltyNumber, EnrolmentUtil.buildItsaEnrolment(testMtdItId), isLPP = true)
+          successfulGetMultiplePenalties(penaltyDataLPP.penaltyNumber, EnrolmentUtil.buildItsaEnrolment(testMtdItId))
+
+          val result = get(s"/initialise-appeal?penaltyId=${penaltyDataLPP.penaltyNumber}&isLPP=true&isAdditional=false", isAgent = true)
+
+          result.status shouldBe SEE_OTHER
+          result.header("Location") shouldBe Some(routes.AppealStartController.onPageLoad().url)
+          SessionCookieCrumbler.getSessionMap(result).get(IncomeTaxSessionKeys.journeyId) shouldBe Some(testJourneyId)
+
+          userAnswers.getUserAnswer(testJourneyId).futureValue shouldBe Some(UserAnswers(
+            journeyId = testJourneyId,
+            data = Json.obj(
+              IncomeTaxSessionKeys.penaltyData -> Json.obj(
+                "penaltyNumber" -> penaltyDataLPP.penaltyNumber,
+                "appealData" -> Json.obj(
+                  "type" -> PenaltyTypeEnum.Late_Payment,
+                  "startDate" -> LocalDate.of(2020, 1, 1),
+                  "endDate" -> LocalDate.of(2020, 1, 31),
+                  "dueDate" -> LocalDate.of(2020, 3, 7),
+                  "dateCommunicationSent" -> LocalDate.of(2020, 3, 8)
+                ),
+                "multiplePenaltiesData" -> Json.obj(
+                  "firstPenaltyChargeReference" -> "123456789",
+                  "firstPenaltyAmount" -> 101.01,
+                  "secondPenaltyChargeReference" -> "123456790",
+                  "secondPenaltyAmount" -> 1.02,
+                  "firstPenaltyCommunicationDate" -> "2023-04-06",
+                  "secondPenaltyCommunicationDate" -> "2023-04-07"
+                )
+              )
+            ),
+            lastUpdated = testDateTime.toInstant(ZoneOffset.UTC)
+          ))
+        }
       }
+    }
 
-      "the user is an authorised agent" in {
-        stubAuth(OK, successfulAgentAuthResponse)
-        val result = get("/initialise-appeal?penaltyId=1", isAgent = true)
+    "penalty appeal data fails to be returned from penalties BE" should {
+      "render an ISE" in {
 
-        result.status shouldBe SEE_OTHER
-        result.header("Location") shouldBe Some(routes.AppealStartController.onPageLoad().url)
-        SessionCookieCrumbler.getSessionMap(result).get(IncomeTaxSessionKeys.journeyId) shouldBe Some(testJourneyId)
+        stubAuth(OK, successfulIndividualAuthResponse)
+        failedGetAppealDataResponse(penaltyDataLSP.penaltyNumber, EnrolmentUtil.buildItsaEnrolment(testMtdItId))
 
-        userAnswers.getUserAnswer(testJourneyId).futureValue shouldBe Some(UserAnswers(
-          journeyId = testJourneyId,
-          data = Json.obj(
-            IncomeTaxSessionKeys.penaltyNumber -> "1"
-          ),
-          lastUpdated = testDateTime.toInstant(ZoneOffset.UTC)
-        ))
+        val result = get(s"/initialise-appeal?penaltyId=${penaltyDataLSP.penaltyNumber}&isLPP=false&isAdditional=false")
+
+        result.status shouldBe INTERNAL_SERVER_ERROR
       }
     }
   }

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/LateAppealControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/LateAppealControllerISpec.scala
@@ -23,7 +23,6 @@ import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.LateAppealForm
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{LateAppealPage, ReasonableExcusePage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
@@ -54,7 +53,7 @@ class LateAppealControllerISpec extends ComponentSpecHelper with ViewSpecHelper 
   for (reason <- reasonsList) {
 
     val userAnswersWithReason =
-      UserAnswers(testJourneyId).setAnswer(ReasonableExcusePage, reason._1)
+      emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, reason._1)
 
     s"GET /making-a-late-appeal with ${reason._1}" should {
 
@@ -132,7 +131,7 @@ class LateAppealControllerISpec extends ComponentSpecHelper with ViewSpecHelper 
 
   "POST /making-a-late-appeal" when {
 
-    val userAnswersWithReason = UserAnswers(testJourneyId).setAnswer(ReasonableExcusePage, "bereavement")
+    val userAnswersWithReason = emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, "bereavement")
 
     "the text area content is valid" should {
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/LateAppealControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/LateAppealControllerISpec.scala
@@ -21,16 +21,21 @@ import org.jsoup.Jsoup
 import org.mongodb.scala.Document
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.LateAppealForm
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{LateAppealPage, ReasonableExcusePage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 class LateAppealControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(En.code)))
 
   lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
 
@@ -100,7 +105,10 @@ class LateAppealControllerISpec extends ComponentSpecHelper with ViewSpecHelper 
 
           document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
           document.title() shouldBe s"This penalty point was issued more than ${reason._2} days ago - Appeal a Self Assessment penalty - GOV.UK"
-          document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+          document.getElementById("captionSpan").text() shouldBe LateAppealMessages.English.lspCaption(
+            dateToString(lateSubmissionAppealData.startDate),
+            dateToString(lateSubmissionAppealData.endDate)
+          )
           document.getH1Elements.text() shouldBe s"This penalty point was issued more than ${reason._2} days ago"
           document.getElementById("infoDaysParagraph").text() shouldBe s"You usually need to appeal within ${reason._2} days of the date on the penalty notice."
           document.getElementsByAttributeValue("for", s"${LateAppealForm.key}").text() shouldBe s"Tell us why you could not appeal within ${reason._2} days"
@@ -118,7 +126,10 @@ class LateAppealControllerISpec extends ComponentSpecHelper with ViewSpecHelper 
 
           document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
           document.title() shouldBe s"This penalty point was issued more than ${reason._2} days ago - Appeal a Self Assessment penalty - GOV.UK"
-          document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+          document.getElementById("captionSpan").text() shouldBe LateAppealMessages.English.lspCaption(
+            dateToString(lateSubmissionAppealData.startDate),
+            dateToString(lateSubmissionAppealData.endDate)
+          )
           document.getH1Elements.text() shouldBe s"This penalty point was issued more than ${reason._2} days ago"
           document.getElementById("infoDaysParagraph").text() shouldBe s"You usually need to appeal within ${reason._2} days of the date on the penalty notice."
           document.getElementsByAttributeValue("for", s"${LateAppealForm.key}").text() shouldBe s"Tell us why you could not appeal within ${reason._2} days"

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ReasonableExcuseControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ReasonableExcuseControllerISpec.scala
@@ -21,17 +21,22 @@ import org.jsoup.Jsoup
 import org.mongodb.scala.Document
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.ReasonableExcusesForm
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.ReasonableExcusePage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 
 class ReasonableExcuseControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(En.code)))
 
   lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
 
@@ -74,7 +79,10 @@ class ReasonableExcuseControllerISpec extends ComponentSpecHelper with ViewSpecH
 
         document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
         document.title() shouldBe "What was the reason for missing the submission deadline? - Appeal a Self Assessment penalty - GOV.UK"
-        document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+        document.getElementById("captionSpan").text() shouldBe ReasonableExcuseMessages.English.lspCaption(
+          dateToString(lateSubmissionAppealData.startDate),
+          dateToString(lateSubmissionAppealData.endDate)
+        )
         document.getH1Elements.text() shouldBe "What was the reason for missing the submission deadline?"
         document.getHintText.get(0).text() shouldBe "If more than one reason applies, choose the one that had the most direct impact on your ability to meet the deadline."
         document.getElementsByAttributeValue("for", "reasonableExcuse").text() shouldBe "Bereavement (someone died)"
@@ -97,7 +105,10 @@ class ReasonableExcuseControllerISpec extends ComponentSpecHelper with ViewSpecH
 
         document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
         document.title() shouldBe "What was the reason for missing the submission deadline? - Appeal a Self Assessment penalty - GOV.UK"
-        document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+        document.getElementById("captionSpan").text() shouldBe ReasonableExcuseMessages.English.lspCaption(
+          dateToString(lateSubmissionAppealData.startDate),
+          dateToString(lateSubmissionAppealData.endDate)
+        )
         document.getH1Elements.text() shouldBe "What was the reason for missing the submission deadline?"
         document.getHintText.get(0).text() shouldBe "If more than one reason applies, choose the one that had the most direct impact on your client’s ability to meet the deadline."
         document.getElementsByAttributeValue("for", "reasonableExcuse").text() shouldBe "Bereavement (someone died)"

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ReasonableExcuseControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ReasonableExcuseControllerISpec.scala
@@ -23,7 +23,6 @@ import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.ReasonableExcusesForm
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.ReasonableExcusePage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
@@ -38,7 +37,7 @@ class ReasonableExcuseControllerISpec extends ComponentSpecHelper with ViewSpecH
 
   override def beforeEach(): Unit = {
     userAnswersRepo.collection.deleteMany(Document()).toFuture().futureValue
-    userAnswersRepo.upsertUserAnswer(UserAnswers(testJourneyId)).futureValue
+    userAnswersRepo.upsertUserAnswer(emptyUerAnswersWithLSP).futureValue
     super.beforeEach()
   }
 
@@ -49,7 +48,7 @@ class ReasonableExcuseControllerISpec extends ComponentSpecHelper with ViewSpecH
       "the user is an authorised individual" in {
         stubAuth(OK, successfulIndividualAuthResponse)
         userAnswersRepo.upsertUserAnswer(
-          UserAnswers(testJourneyId).setAnswer(ReasonableExcusePage, "bereavement")
+          emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, "bereavement")
         ).futureValue
         val result = get("/reason-for-missing-deadline")
         result.status shouldBe OK
@@ -119,7 +118,7 @@ class ReasonableExcuseControllerISpec extends ComponentSpecHelper with ViewSpecH
 
   "POST /reason-for-missing-deadline" when {
 
-    val userAnswersWithReason = UserAnswers(testJourneyId).setAnswer(ReasonableExcusePage, "bereavement")
+    val userAnswersWithReason = emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, "bereavement")
 
     "a valid radio option has been selected" should {
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ViewAppealDetailsControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ViewAppealDetailsControllerISpec.scala
@@ -21,7 +21,6 @@ import org.mongodb.scala.Document
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.OK
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.ReasonableExcusePage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
@@ -69,7 +68,7 @@ class ViewAppealDetailsControllerISpec extends ComponentSpecHelper with ViewSpec
 
   for (reason <- reasonsList) {
 
-    val userAnswersWithReason = UserAnswers(testJourneyId).setAnswer(ReasonableExcusePage, reason._1)
+    val userAnswersWithReason = emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, reason._1)
 
     s"GET /appeal-details with ${reason._1}" should {
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhatCausedYouToMissDeadlineControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhatCausedYouToMissDeadlineControllerISpec.scala
@@ -21,17 +21,22 @@ import org.jsoup.Jsoup
 import org.mongodb.scala.Document
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.WhatCausedYouToMissDeadlineForm
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.AgentClientEnum
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.WhatCausedYouToMissDeadlinePage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 class WhatCausedYouToMissDeadlineControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(En.code)))
 
   lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
 
@@ -72,7 +77,10 @@ class WhatCausedYouToMissDeadlineControllerISpec extends ComponentSpecHelper wit
 
         document.getServiceName.text() shouldBe WhatCausedYouToMissDeadlineMessages.English.serviceName
         document.title() should include(WhatCausedYouToMissDeadlineMessages.English.titleAndHeading)
-        document.getElementById("captionSpan").text() shouldBe WhatCausedYouToMissDeadlineMessages.English.caption("6 July 2027", "5 October 2027")
+        document.getElementById("captionSpan").text() shouldBe WhatCausedYouToMissDeadlineMessages.English.lspCaption(
+          dateToString(lateSubmissionAppealData.startDate),
+          dateToString(lateSubmissionAppealData.endDate)
+        )
         document.getH1Elements.text() shouldBe WhatCausedYouToMissDeadlineMessages.English.titleAndHeading
         document.getSubmitButton.text() shouldBe WhatCausedYouToMissDeadlineMessages.English.continue
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhatCausedYouToMissDeadlineControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhatCausedYouToMissDeadlineControllerISpec.scala
@@ -24,7 +24,6 @@ import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.WhatCausedYouToMissDeadlineForm
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.AgentClientEnum
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.WhatCausedYouToMissDeadlinePage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
@@ -38,7 +37,7 @@ class WhatCausedYouToMissDeadlineControllerISpec extends ComponentSpecHelper wit
 
   override def beforeEach(): Unit = {
     userAnswersRepo.collection.deleteMany(Document()).toFuture().futureValue
-    userAnswersRepo.upsertUserAnswer(UserAnswers(testJourneyId))
+    userAnswersRepo.upsertUserAnswer(emptyUerAnswersWithLSP)
     super.beforeEach()
   }
 
@@ -50,7 +49,7 @@ class WhatCausedYouToMissDeadlineControllerISpec extends ComponentSpecHelper wit
       "the user is an authorised agent AND the page has already been answered" in {
         stubAuth(OK, successfulAgentAuthResponse)
         userAnswersRepo.upsertUserAnswer(
-          UserAnswers(testJourneyId).setAnswer(WhatCausedYouToMissDeadlinePage, AgentClientEnum.agent)
+          emptyUerAnswersWithLSP.setAnswer(WhatCausedYouToMissDeadlinePage, AgentClientEnum.agent)
         ).futureValue
 
         val result = get("/what-caused-you-to-miss-the-deadline", isAgent = true)

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventEndControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventEndControllerISpec.scala
@@ -39,7 +39,7 @@ class WhenDidEventEndControllerISpec extends ComponentSpecHelper with ViewSpecHe
 
   val testStartDate: LocalDate = LocalDate.of(2024, 3, 2)
 
-  val userAnswer: UserAnswers = UserAnswers(testJourneyId)
+  val userAnswer: UserAnswers = emptyUerAnswersWithLSP
     .setAnswer(ReasonableExcusePage, "technicalIssues")
     .setAnswer(WhenDidEventHappenPage, testStartDate)
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventEndControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventEndControllerISpec.scala
@@ -21,12 +21,15 @@ import org.jsoup.Jsoup
 import org.mongodb.scala.Document
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status._
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.WhenDidEventEndForm
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{ReasonableExcusePage, WhenDidEventEndPage, WhenDidEventHappenPage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 import java.time.LocalDate
@@ -36,6 +39,8 @@ class WhenDidEventEndControllerISpec extends ComponentSpecHelper with ViewSpecHe
   lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(En.code)))
 
   val testStartDate: LocalDate = LocalDate.of(2024, 3, 2)
 
@@ -88,7 +93,10 @@ class WhenDidEventEndControllerISpec extends ComponentSpecHelper with ViewSpecHe
 
         document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
         document.title() shouldBe "When did the software or technology issues end? - Appeal a Self Assessment penalty - GOV.UK"
-        document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+        document.getElementById("captionSpan").text() shouldBe WhenDidEventEndMessages.English.lspCaption(
+          dateToString(lateSubmissionAppealData.startDate),
+          dateToString(lateSubmissionAppealData.endDate)
+        )
         document.getH1Elements.text() shouldBe "When did the software or technology issues end?"
         document.getElementById("date-hint").text() shouldBe "For example, 12 3 2018"
         document.getElementsByAttributeValue("for", "date.day").text() shouldBe "Day"
@@ -105,7 +113,10 @@ class WhenDidEventEndControllerISpec extends ComponentSpecHelper with ViewSpecHe
 
         document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
         document.title() shouldBe "When did the software or technology issues end? - Appeal a Self Assessment penalty - GOV.UK"
-        document.getElementById("captionSpan").text() shouldBe "Late submission penalty point: 6 July 2027 to 5 October 2027"
+        document.getElementById("captionSpan").text() shouldBe WhenDidEventEndMessages.English.lspCaption(
+          dateToString(lateSubmissionAppealData.startDate),
+          dateToString(lateSubmissionAppealData.endDate)
+        )
         document.getH1Elements.text() shouldBe "When did the software or technology issues end?"
         document.getElementById("date-hint").text() shouldBe "For example, 12 3 2018"
         document.getElementsByAttributeValue("for", "date.day").text() shouldBe "Day"

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenControllerISpec.scala
@@ -21,11 +21,14 @@ import org.jsoup.Jsoup
 import org.mongodb.scala.Document
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.WhenDidEventHappenForm
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{ReasonableExcusePage, WhenDidEventHappenPage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 import java.time.LocalDate
@@ -33,6 +36,8 @@ import java.time.LocalDate
 class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(En.code)))
 
   lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
 
@@ -104,7 +109,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
           document.getServiceName.text() shouldBe WhenDidEventHappenMessages.English.serviceName
           document.title() shouldBe WhenDidEventHappenMessages.English.titleWithSuffix(WhenDidEventHappenMessages.English.headingAndTitle(reason, isLPP = false, isAgent = false, wasClientInformationIssue = false))
-          document.getElementById("captionSpan").text() shouldBe WhenDidEventHappenMessages.English.caption("6 July 2027", "5 October 2027")
+          document.getElementById("captionSpan").text() shouldBe WhenDidEventHappenMessages.English.lspCaption(
+            dateToString(lateSubmissionAppealData.startDate),
+            dateToString(lateSubmissionAppealData.endDate)
+          )
           document.getH1Elements.text() shouldBe WhenDidEventHappenMessages.English.headingAndTitle(reason, isLPP = false, isAgent = false, wasClientInformationIssue = false)
           document.getElementById("date-hint").text() shouldBe "For example, 12 3 2018"
           document.getElementsByAttributeValue("for", "date.day").text() shouldBe "Day"
@@ -123,7 +131,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
           document.getServiceName.text() shouldBe WhenDidEventHappenMessages.English.serviceName
           document.title() shouldBe WhenDidEventHappenMessages.English.titleWithSuffix(WhenDidEventHappenMessages.English.headingAndTitle(reason, isLPP = false, isAgent = true, wasClientInformationIssue = false))
-          document.getElementById("captionSpan").text() shouldBe WhenDidEventHappenMessages.English.caption("6 July 2027", "5 October 2027")
+          document.getElementById("captionSpan").text() shouldBe WhenDidEventHappenMessages.English.lspCaption(
+            dateToString(lateSubmissionAppealData.startDate),
+            dateToString(lateSubmissionAppealData.endDate)
+          )
           document.getH1Elements.text() shouldBe WhenDidEventHappenMessages.English.headingAndTitle(reason, isLPP = false, isAgent = true, wasClientInformationIssue = false)
           document.getElementById("date-hint").text() shouldBe "For example, 12 3 2018"
           document.getElementsByAttributeValue("for", "date.day").text() shouldBe "Day"

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenControllerISpec.scala
@@ -23,7 +23,6 @@ import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.WhenDidEventHappenForm
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{ReasonableExcusePage, WhenDidEventHappenPage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
@@ -56,7 +55,7 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
   for (reason <- reasonsList) {
 
     val userAnswersWithReason =
-      UserAnswers(testJourneyId).setAnswer(ReasonableExcusePage, reason)
+      emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, reason)
 
     s"GET /when-did-the-event-happen with $reason" should {
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhenDidEventHappenControllerISpec.scala
@@ -25,17 +25,20 @@ import play.api.i18n.{Lang, Messages, MessagesApi}
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.WhenDidEventHappenForm
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.PenaltyData
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{ReasonableExcusePage, WhenDidEventHappenPage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, IncomeTaxSessionKeys, NavBarTesterHelper, TimeMachine, ViewSpecHelper}
 
 import java.time.LocalDate
 
 class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  lazy val timeMachine: TimeMachine = app.injector.instanceOf[TimeMachine]
   implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
   implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(En.code)))
 
@@ -52,27 +55,38 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
     "other"
   )
 
-  override def beforeEach(): Unit = {
+  class Setup(reason: String, isLate: Boolean = false) {
+
     userAnswersRepo.collection.deleteMany(Document()).toFuture().futureValue
-    super.beforeEach()
+
+    val lateDays: Int = if(reason == "bereavement") appConfig.bereavementLateDays else appConfig.lateDays
+
+    val userAnswers: UserAnswers = emptyUserAnswers
+      .setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyDataLSP.copy(
+        appealData = lateSubmissionAppealData.copy(
+          dateCommunicationSent =
+            if (isLate) timeMachine.getCurrentDate.minusDays(lateDays + 1)
+            else        timeMachine.getCurrentDate.minusDays(1)
+        )
+      ))
+      .setAnswer(ReasonableExcusePage, reason)
+
+    userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
   }
 
   for (reason <- reasonsList) {
 
-    val userAnswersWithReason =
-      emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, reason)
-
     s"GET /when-did-the-event-happen with $reason" should {
 
       testNavBar(url = "/honesty-declaration") {
-        userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+        userAnswersRepo.upsertUserAnswer(emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, reason)).futureValue
       }
 
       "return an OK with a view" when {
-        "the user is an authorised individual AND the page has already been answered" in {
+        "the user is an authorised individual AND the page has already been answered" in new Setup(reason) {
           stubAuth(OK, successfulIndividualAuthResponse)
 
-          userAnswersRepo.upsertUserAnswer(userAnswersWithReason.setAnswer(WhenDidEventHappenPage, LocalDate.of(2024, 4, 2))).futureValue
+          userAnswersRepo.upsertUserAnswer(userAnswers.setAnswer(WhenDidEventHappenPage, LocalDate.of(2024, 4, 2))).futureValue
 
           val result = get("/when-did-the-event-happen")
 
@@ -83,9 +97,9 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
           document.getElementById(s"${WhenDidEventHappenForm.key + ".year"}").`val`() shouldBe "2024"
         }
 
-        "the user is an authorised agent AND page NOT already answered" in {
+        "the user is an authorised agent AND page NOT already answered" in new Setup(reason) {
           stubAuth(OK, successfulAgentAuthResponse)
-          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+          userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
           val result = get("/when-did-the-event-happen", isAgent = true)
 
@@ -99,9 +113,9 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
       }
 
       "the page has the correct elements" when {
-        "the user is an authorised individual" in {
+        "the user is an authorised individual" in new Setup(reason) {
           stubAuth(OK, successfulIndividualAuthResponse)
-          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+          userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
           val result = get("/when-did-the-event-happen")
 
@@ -121,9 +135,9 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
           document.getSubmitButton.text() shouldBe "Continue"
         }
 
-        "the user is an authorised agent" in {
+        "the user is an authorised agent" in new Setup(reason) {
           stubAuth(OK, successfulAgentAuthResponse)
-          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+          userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
           val result = get("/when-did-the-event-happen", isAgent = true)
 
@@ -148,29 +162,52 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
     s"POST /when-did-the-event-happen $reason" when {
 
-      "the date is valid" should {
+      "the date is valid" when {
 
         if (reason == "bereavement" | reason == "fireOrFlood") {
-          "save the value to UserAnswers AND redirect to the making-a-late-appeal page" in {
 
-            stubAuth(OK, successfulIndividualAuthResponse)
-            userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+          "the appeal is late" should {
 
-            val result = post("/when-did-the-event-happen")(Map(
-              WhenDidEventHappenForm.key + ".day" -> "02",
-              WhenDidEventHappenForm.key + ".month" -> "04",
-              WhenDidEventHappenForm.key + ".year" -> "2024"))
+            "save the value to UserAnswers AND redirect to the making-a-late-appeal page" in new Setup(reason, isLate = true) {
 
-            result.status shouldBe SEE_OTHER
-            result.header("Location") shouldBe Some(routes.LateAppealController.onPageLoad().url)
+              stubAuth(OK, successfulIndividualAuthResponse)
+              userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
-            userAnswersRepo.getUserAnswer(testJourneyId).futureValue.flatMap(_.getAnswer(WhenDidEventHappenPage)) shouldBe Some(LocalDate.of(2024, 4, 2))
+              val result = post("/when-did-the-event-happen")(Map(
+                WhenDidEventHappenForm.key + ".day" -> "02",
+                WhenDidEventHappenForm.key + ".month" -> "04",
+                WhenDidEventHappenForm.key + ".year" -> "2024"))
+
+              result.status shouldBe SEE_OTHER
+              result.header("Location") shouldBe Some(routes.LateAppealController.onPageLoad().url)
+
+              userAnswersRepo.getUserAnswer(testJourneyId).futureValue.flatMap(_.getAnswer(WhenDidEventHappenPage)) shouldBe Some(LocalDate.of(2024, 4, 2))
+            }
+          }
+
+          "the appeal is NOT late" should {
+
+            "save the value to UserAnswers AND redirect to the Check Answers page" in new Setup(reason) {
+
+              stubAuth(OK, successfulIndividualAuthResponse)
+              userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
+
+              val result = post("/when-did-the-event-happen")(Map(
+                WhenDidEventHappenForm.key + ".day" -> "02",
+                WhenDidEventHappenForm.key + ".month" -> "04",
+                WhenDidEventHappenForm.key + ".year" -> "2024"))
+
+              result.status shouldBe SEE_OTHER
+              result.header("Location") shouldBe Some(routes.CheckYourAnswersController.onPageLoad().url)
+
+              userAnswersRepo.getUserAnswer(testJourneyId).futureValue.flatMap(_.getAnswer(WhenDidEventHappenPage)) shouldBe Some(LocalDate.of(2024, 4, 2))
+            }
           }
         } else if (reason == "crime") {
-          "save the value to UserAnswers AND redirect to the has-this-crime-been-reported page" in {
+          "save the value to UserAnswers AND redirect to the has-this-crime-been-reported page" in new Setup(reason) {
 
             stubAuth(OK, successfulIndividualAuthResponse)
-            userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+            userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
             val result = post("/when-did-the-event-happen")(Map(
               WhenDidEventHappenForm.key + ".day" -> "02",
@@ -183,10 +220,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
             userAnswersRepo.getUserAnswer(testJourneyId).futureValue.flatMap(_.getAnswer(WhenDidEventHappenPage)) shouldBe Some(LocalDate.of(2024, 4, 2))
           }
         } else if (reason == "technicalIssue") {
-          "save the value to UserAnswers AND redirect to the when-did-the-event-end page" in {
+          "save the value to UserAnswers AND redirect to the when-did-the-event-end page" in new Setup(reason) {
 
             stubAuth(OK, successfulIndividualAuthResponse)
-            userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+            userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
             val result = post("/when-did-the-event-happen")(Map(
               WhenDidEventHappenForm.key + ".day" -> "02",
@@ -203,10 +240,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
       "the date is not valid - day missing" should {
 
-        "render a bad request with the Form Error on the page with a link to the field in error" in {
+        "render a bad request with the Form Error on the page with a link to the field in error" in new Setup(reason) {
 
             stubAuth(OK, successfulIndividualAuthResponse)
-            userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+            userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
             val result = post("/when-did-the-event-happen")(Map(
               WhenDidEventHappenForm.key + ".day" -> "",
@@ -228,10 +265,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
       "the date is not valid - month missing" should {
 
-        "render a bad request with the Form Error on the page with a link to the field in error" in {
+        "render a bad request with the Form Error on the page with a link to the field in error" in new Setup(reason) {
 
             stubAuth(OK, successfulIndividualAuthResponse)
-            userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+            userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
             val result = post("/when-did-the-event-happen")(Map(
               WhenDidEventHappenForm.key + ".day" -> "02",
@@ -253,10 +290,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
       "the date is not valid - year missing" should {
 
-        "render a bad request with the Form Error on the page with a link to the field in error" in {
+        "render a bad request with the Form Error on the page with a link to the field in error" in new Setup(reason) {
 
           stubAuth(OK, successfulIndividualAuthResponse)
-          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+          userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
           val result = post("/when-did-the-event-happen")(Map(
             WhenDidEventHappenForm.key + ".day" -> "02",
@@ -278,10 +315,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
       "the date is not valid - two fields missing - day and month" should {
 
-        "render a bad request with the Form Error on the page with a link to the field in error" in {
+        "render a bad request with the Form Error on the page with a link to the field in error" in new Setup(reason) {
 
           stubAuth(OK, successfulIndividualAuthResponse)
-          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+          userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
           val result = post("/when-did-the-event-happen")(Map(
             WhenDidEventHappenForm.key + ".day" -> "",
@@ -303,10 +340,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
       "the date is not valid - two fields missing - day and year" should {
 
-        "render a bad request with the Form Error on the page with a link to the field in error" in {
+        "render a bad request with the Form Error on the page with a link to the field in error" in new Setup(reason) {
 
           stubAuth(OK, successfulIndividualAuthResponse)
-          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+          userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
           val result = post("/when-did-the-event-happen")(Map(
             WhenDidEventHappenForm.key + ".day" -> "",
@@ -328,10 +365,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
       "the date is not valid - two fields missing - month and year" should {
 
-        "render a bad request with the Form Error on the page with a link to the field in error" in {
+        "render a bad request with the Form Error on the page with a link to the field in error" in new Setup(reason) {
 
           stubAuth(OK, successfulIndividualAuthResponse)
-          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+          userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
           val result = post("/when-did-the-event-happen")(Map(
             WhenDidEventHappenForm.key + ".day" -> "04",
@@ -353,10 +390,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
       "the date is not valid - all fields missing" should {
 
-        "render a bad request with the Form Error on the page with a link to the field in error" in {
+        "render a bad request with the Form Error on the page with a link to the field in error" in new Setup(reason) {
 
           stubAuth(OK, successfulIndividualAuthResponse)
-          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+          userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
           val result = post("/when-did-the-event-happen")(Map(
             WhenDidEventHappenForm.key + ".day" -> "",
@@ -378,10 +415,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
       "the date is not valid - Invalid format day" should {
 
-        "render a bad request with the Form Error on the page with a link to the field in error" in {
+        "render a bad request with the Form Error on the page with a link to the field in error" in new Setup(reason) {
 
           stubAuth(OK, successfulIndividualAuthResponse)
-          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+          userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
           val result = post("/when-did-the-event-happen")(Map(
             WhenDidEventHappenForm.key + ".day" -> "aa",
@@ -403,10 +440,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
       "the date is not valid - Invalid format month" should {
 
-        "render a bad request with the Form Error on the page with a link to the field in error" in {
+        "render a bad request with the Form Error on the page with a link to the field in error" in new Setup(reason) {
 
           stubAuth(OK, successfulIndividualAuthResponse)
-          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+          userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
           val result = post("/when-did-the-event-happen")(Map(
             WhenDidEventHappenForm.key + ".day" -> "02",
@@ -428,10 +465,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
       "the date is not valid - Invalid format year" should {
 
-        "render a bad request with the Form Error on the page with a link to the field in error" in {
+        "render a bad request with the Form Error on the page with a link to the field in error" in new Setup(reason) {
 
           stubAuth(OK, successfulIndividualAuthResponse)
-          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+          userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
           val result = post("/when-did-the-event-happen")(Map(
             WhenDidEventHappenForm.key + ".day" -> "02",
@@ -453,10 +490,10 @@ class WhenDidEventHappenControllerISpec extends ComponentSpecHelper with ViewSpe
 
       "the date is not valid - date is in the future" should {
 
-        "render a bad request with the Form Error on the page with a link to the field in error" in {
+        "render a bad request with the Form Error on the page with a link to the field in error" in new Setup(reason) {
 
           stubAuth(OK, successfulIndividualAuthResponse)
-          userAnswersRepo.upsertUserAnswer(userAnswersWithReason).futureValue
+          userAnswersRepo.upsertUserAnswer(userAnswers).futureValue
 
           val result = post("/when-did-the-event-happen")(Map(
             WhenDidEventHappenForm.key + ".day" -> "02",

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhoPlannedToSubmitControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhoPlannedToSubmitControllerISpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
+import fixtures.BaseFixtures
 import fixtures.messages.WhoPlannedToSubmitMessages
 import org.jsoup.Jsoup
 import org.mongodb.scala.Document
@@ -24,13 +25,12 @@ import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.WhoPlannedToSubmitForm
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.AgentClientEnum
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.WhoPlannedToSubmitPage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
-class WhoPlannedToSubmitControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper {
+class WhoPlannedToSubmitControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper with BaseFixtures {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
 
@@ -38,7 +38,7 @@ class WhoPlannedToSubmitControllerISpec extends ComponentSpecHelper with ViewSpe
 
   override def beforeEach(): Unit = {
     userAnswersRepo.collection.deleteMany(Document()).toFuture().futureValue
-    userAnswersRepo.upsertUserAnswer(UserAnswers(testJourneyId))
+    userAnswersRepo.upsertUserAnswer(emptyUerAnswersWithLSP)
     super.beforeEach()
   }
 
@@ -50,7 +50,7 @@ class WhoPlannedToSubmitControllerISpec extends ComponentSpecHelper with ViewSpe
       "the user is an authorised agent AND the page has already been answered" in {
         stubAuth(OK, successfulAgentAuthResponse)
         userAnswersRepo.upsertUserAnswer(
-          UserAnswers(testJourneyId).setAnswer(WhoPlannedToSubmitPage, AgentClientEnum.agent)
+          emptyUerAnswersWithLSP.setAnswer(WhoPlannedToSubmitPage, AgentClientEnum.agent)
         ).futureValue
 
         val result = get("/who-planned-to-submit", isAgent = true)

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhoPlannedToSubmitControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/WhoPlannedToSubmitControllerISpec.scala
@@ -22,17 +22,22 @@ import org.jsoup.Jsoup
 import org.mongodb.scala.Document
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.En
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.WhoPlannedToSubmitForm
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.AgentClientEnum
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.WhoPlannedToSubmitPage
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.repositories.UserAnswersRepository
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.stubs.AuthStub
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{ComponentSpecHelper, NavBarTesterHelper, ViewSpecHelper}
 
 class WhoPlannedToSubmitControllerISpec extends ComponentSpecHelper with ViewSpecHelper with AuthStub with NavBarTesterHelper with BaseFixtures {
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit lazy val messages: Messages = messagesApi.preferred(Seq(Lang(En.code)))
 
   lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
 
@@ -73,7 +78,10 @@ class WhoPlannedToSubmitControllerISpec extends ComponentSpecHelper with ViewSpe
 
         document.getServiceName.text() shouldBe WhoPlannedToSubmitMessages.English.serviceName
         document.title() should include(WhoPlannedToSubmitMessages.English.titleAndHeading)
-        document.getElementById("captionSpan").text() shouldBe WhoPlannedToSubmitMessages.English.caption("6 July 2027", "5 October 2027")
+        document.getElementById("captionSpan").text() shouldBe WhoPlannedToSubmitMessages.English.lspCaption(
+          dateToString(lateSubmissionAppealData.startDate),
+          dateToString(lateSubmissionAppealData.endDate)
+        )
         document.getH1Elements.text() shouldBe WhoPlannedToSubmitMessages.English.titleAndHeading
         document.getSubmitButton.text() shouldBe WhoPlannedToSubmitMessages.English.continue
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanCheckAnswersControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanCheckAnswersControllerISpec.scala
@@ -56,7 +56,7 @@ class UpscanCheckAnswersControllerISpec extends ComponentSpecHelper with ViewSpe
   override def beforeEach(): Unit = {
     userAnswersRepo.collection.deleteMany(Document()).toFuture().futureValue
     fileUploadRepo.collection.deleteMany(Document()).toFuture().futureValue
-    userAnswersRepo.upsertUserAnswer(UserAnswers(testJourneyId)).futureValue
+    userAnswersRepo.upsertUserAnswer(emptyUerAnswersWithLSP).futureValue
     super.beforeEach()
   }
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanInitiateControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanInitiateControllerISpec.scala
@@ -57,7 +57,7 @@ class UpscanInitiateControllerISpec extends ComponentSpecHelper with ViewSpecHel
   override def beforeEach(): Unit = {
     userAnswersRepo.collection.deleteMany(Document()).toFuture().futureValue
     fileUploadRepo.collection.deleteMany(Document()).toFuture().futureValue
-    userAnswersRepo.upsertUserAnswer(UserAnswers(testJourneyId)).futureValue
+    userAnswersRepo.upsertUserAnswer(emptyUerAnswersWithLSP).futureValue
     super.beforeEach()
   }
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanRemoveFileControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanRemoveFileControllerISpec.scala
@@ -56,7 +56,7 @@ class UpscanRemoveFileControllerISpec extends ComponentSpecHelper with ViewSpecH
   override def beforeEach(): Unit = {
     userAnswersRepo.collection.deleteMany(Document()).toFuture().futureValue
     fileUploadRepo.collection.deleteMany(Document()).toFuture().futureValue
-    userAnswersRepo.upsertUserAnswer(UserAnswers(testJourneyId)).futureValue
+    userAnswersRepo.upsertUserAnswer(emptyUerAnswersWithLSP).futureValue
     super.beforeEach()
   }
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/stubs/PenaltiesStub.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/stubs/PenaltiesStub.scala
@@ -138,9 +138,9 @@ trait PenaltiesStub {
     )
   }
 
-  def successfulGetMultiplePenalties(penaltyId: String, enrolmentKey: String, isStubbed: Boolean = false): StubMapping = {
+  def successfulGetMultiplePenalties(penaltyId: String, mtditid: String, isStubbed: Boolean = false): StubMapping = {
     stubFor(
-      get(urlEqualTo(multiplePenaltiesUri(penaltyId, enrolmentKey, isStubbed)))
+      get(urlEqualTo(multiplePenaltiesUri(penaltyId, mtditid, isStubbed)))
         .willReturn(
           aResponse()
             .withStatus(Status.OK)

--- a/test-fixtures/fixtures/BaseFixtures.scala
+++ b/test-fixtures/fixtures/BaseFixtures.scala
@@ -16,9 +16,16 @@
 
 package fixtures
 
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.AnyContent
 import play.api.test.FakeRequest
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.MultiplePenaltiesData
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{CurrentUserRequest, CurrentUserRequestWithAnswers}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{AppealData, CrimeReportedEnum, CurrentUserRequest, CurrentUserRequestWithAnswers, PenaltyData, PenaltyTypeEnum}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{CrimeReportedPage, HonestyDeclarationPage, ReasonableExcusePage, WhenDidEventHappenPage}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.IncomeTaxSessionKeys
+
+import java.time.LocalDate
 
 trait BaseFixtures {
 
@@ -26,12 +33,180 @@ trait BaseFixtures {
   val testArn = "00123456"
   val testJourneyId: String = "journeyId123"
 
-  val emptyUserAnswers: UserAnswers = UserAnswers(testJourneyId)
+  val latePaymentAppealData: AppealData = AppealData(
+    `type` = PenaltyTypeEnum.Late_Payment,
+    startDate = LocalDate.of(2024, 1, 1),
+    endDate = LocalDate.of(2024, 1, 31),
+    dueDate = LocalDate.of(2022, 1, 1),
+    dateCommunicationSent = LocalDate.of(2021, 12, 1)
+  )
 
-  def userRequestWithAnswers(userAnswers: UserAnswers): CurrentUserRequestWithAnswers[_] =
-    CurrentUserRequestWithAnswers(userAnswers)(CurrentUserRequest(testMtdItId, None)(FakeRequest()))
+  val lateSubmissionAppealData: AppealData = AppealData(
+    `type` = PenaltyTypeEnum.Late_Submission,
+    startDate = LocalDate.of(2024, 1, 1),
+    endDate = LocalDate.of(2024, 1, 31),
+    dueDate = LocalDate.of(2022, 1, 1),
+    dateCommunicationSent = LocalDate.of(2021, 12, 1)
+  )
 
-  def agentUserRequestWithAnswers(userAnswers: UserAnswers): CurrentUserRequestWithAnswers[_] =
-    CurrentUserRequestWithAnswers(userAnswers)(CurrentUserRequest(testMtdItId, Some(testArn))(FakeRequest()))
+  val multiplePenaltiesModel: MultiplePenaltiesData = MultiplePenaltiesData(
+    firstPenaltyChargeReference = "123456789",
+    firstPenaltyAmount = 101.01,
+    secondPenaltyChargeReference = "123456788",
+    secondPenaltyAmount = 101.02,
+    firstPenaltyCommunicationDate = LocalDate.parse("2022-01-01"),
+    secondPenaltyCommunicationDate = LocalDate.parse("2022-01-02")
+  )
+
+  val penaltyDataLSP: PenaltyData = PenaltyData(
+    penaltyNumber = "123456789",
+    appealData = lateSubmissionAppealData,
+    multiplePenaltiesData = None
+  )
+
+  val penaltyDataLPP: PenaltyData = PenaltyData(
+    penaltyNumber = "123456790",
+    appealData = latePaymentAppealData,
+    multiplePenaltiesData = None
+  )
+
+  val emptyUerAnswersWithLSP: UserAnswers = UserAnswers(testJourneyId).setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyDataLSP)
+
+  val fakeRequestForCrimeJourney: CurrentUserRequestWithAnswers[AnyContent] = {
+
+    val penaltyData = PenaltyData(
+      penaltyNumber = "123456789",
+      appealData = lateSubmissionAppealData,
+      multiplePenaltiesData = None
+    )
+
+    CurrentUserRequestWithAnswers(
+      mtdItId = testMtdItId,
+      userAnswers = emptyUerAnswersWithLSP
+        .setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyData)
+        .setAnswer(HonestyDeclarationPage, true)
+        .setAnswer(CrimeReportedPage, CrimeReportedEnum.yes)
+        .setAnswer(ReasonableExcusePage, "crime")
+        .setAnswer(WhenDidEventHappenPage, LocalDate.of(2022, 1, 1)),
+      penaltyData = penaltyData
+    )(
+      //TODO: These will all move to be UserAnswers as part of future stories
+      FakeRequest().withSession(
+        IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "no"
+      ))
+  }
+
+  val fakeRequestForCrimeJourneyMultiple: CurrentUserRequestWithAnswers[AnyContent] = {
+
+    val penaltyData = PenaltyData(
+      penaltyNumber = "123456789",
+      appealData = latePaymentAppealData,
+      multiplePenaltiesData = Some(multiplePenaltiesModel)
+    )
+
+    CurrentUserRequestWithAnswers(
+      mtdItId = testMtdItId,
+      userAnswers = emptyUerAnswersWithLSP
+        .setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyData)
+        .setAnswer(HonestyDeclarationPage, true)
+        .setAnswer(CrimeReportedPage, CrimeReportedEnum.yes)
+        .setAnswer(ReasonableExcusePage, "crime")
+        .setAnswer(WhenDidEventHappenPage, LocalDate.of(2022, 1, 1)),
+      penaltyData = penaltyData
+    )(
+      //TODO: These will all move to be UserAnswers as part of future stories
+      FakeRequest().withSession(
+        IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "yes"
+      ))
+  }
+
+  val fakeRequestForOtherJourney: CurrentUserRequestWithAnswers[AnyContent] = {
+
+    val penaltyData = PenaltyData(
+      penaltyNumber = "123456789",
+      appealData = lateSubmissionAppealData,
+      multiplePenaltiesData = None
+    )
+
+    CurrentUserRequestWithAnswers(
+      mtdItId = testMtdItId,
+      userAnswers = emptyUerAnswersWithLSP
+        .setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyData)
+        .setAnswer(HonestyDeclarationPage, true)
+        .setAnswer(ReasonableExcusePage, "other")
+        .setAnswer(WhenDidEventHappenPage, LocalDate.of(2022, 1, 1)),
+      penaltyData = penaltyData
+    )(
+      //TODO: These will all move to be UserAnswers as part of future stories
+      FakeRequest().withSession(
+        IncomeTaxSessionKeys.whyReturnSubmittedLate -> "This is a reason.",
+        IncomeTaxSessionKeys.isUploadEvidence -> "yes",
+        IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "no"
+      ))
+  }
+
+  val fakeRequestForOtherJourneyDeclinedUploads: CurrentUserRequestWithAnswers[AnyContent] = {
+
+    val penaltyData = PenaltyData(
+      penaltyNumber = "123456789",
+      appealData = lateSubmissionAppealData,
+      multiplePenaltiesData = None
+    )
+
+    CurrentUserRequestWithAnswers(
+      mtdItId = testMtdItId,
+      userAnswers = emptyUerAnswersWithLSP
+        .setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyData)
+        .setAnswer(HonestyDeclarationPage, true)
+        .setAnswer(ReasonableExcusePage, "other")
+        .setAnswer(WhenDidEventHappenPage, LocalDate.of(2022, 1, 1)),
+      penaltyData = penaltyData
+    )(
+      //TODO: These will all move to be UserAnswers as part of future stories
+      FakeRequest().withSession(
+        IncomeTaxSessionKeys.whyReturnSubmittedLate -> "This is a reason.",
+        IncomeTaxSessionKeys.isUploadEvidence -> "no",
+        IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "no"
+      ))
+  }
+
+  val appealDataAsJson: JsValue = Json.parse(
+    """
+      |{
+      | "type": "LATE_SUBMISSION",
+      | "startDate": "2020-01-01",
+      | "endDate": "2020-01-01",
+      | "dueDate": "2020-02-07",
+      | "dateCommunicationSent": "2020-02-08"
+      |}
+      |""".stripMargin)
+
+  val appealDataAsJsonLPP: JsValue = Json.parse(
+    """
+      |{
+      | "type": "LATE_PAYMENT",
+      | "startDate": "2020-01-01",
+      | "endDate": "2020-01-01",
+      | "dueDate": "2020-02-07",
+      | "dateCommunicationSent": "2020-02-08"
+      |}
+      |""".stripMargin)
+
+  val appealDataAsJsonLPPAdditional: JsValue = Json.parse(
+    """
+      |{
+      | "type": "ADDITIONAL",
+      | "startDate": "2020-01-01",
+      | "endDate": "2020-01-01",
+      | "dueDate": "2020-02-07",
+      | "dateCommunicationSent": "2020-02-08"
+      |}
+      |""".stripMargin)
+
+  def userRequestWithAnswers(userAnswers: UserAnswers, penaltyData: PenaltyData = penaltyDataLSP): CurrentUserRequestWithAnswers[_] =
+    CurrentUserRequestWithAnswers(userAnswers, penaltyData)(CurrentUserRequest(testMtdItId, None)(FakeRequest()))
+
+  def agentUserRequestWithAnswers(userAnswers: UserAnswers, penaltyData: PenaltyData = penaltyDataLSP): CurrentUserRequestWithAnswers[_] =
+    CurrentUserRequestWithAnswers(userAnswers, penaltyData)(CurrentUserRequest(testMtdItId, Some(testArn))(FakeRequest()))
 
 }

--- a/test-fixtures/fixtures/BaseFixtures.scala
+++ b/test-fixtures/fixtures/BaseFixtures.scala
@@ -70,7 +70,8 @@ trait BaseFixtures {
     multiplePenaltiesData = None
   )
 
-  val emptyUerAnswersWithLSP: UserAnswers = UserAnswers(testJourneyId).setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyDataLSP)
+  val emptyUserAnswers: UserAnswers = UserAnswers(testJourneyId)
+  val emptyUerAnswersWithLSP: UserAnswers = emptyUserAnswers.setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyDataLSP)
 
   val fakeRequestForCrimeJourney: CurrentUserRequestWithAnswers[AnyContent] = {
 

--- a/test-fixtures/fixtures/messages/i18n.scala
+++ b/test-fixtures/fixtures/messages/i18n.scala
@@ -20,7 +20,8 @@ import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.Language
 
 sealed trait i18n {
-  def caption(from: String, to: String) = s"Late submission penalty point: $from to $to"
+  def lspCaption(from: String, to: String): String = s"Late submission penalty point: $from to $to".replace("\u00A0", " ")
+  def lppCaption(from: String, to: String): String = s"Late payment penalty: $from to $to".replace("\u00A0", " ")
   val serviceName = "Appeal a Self Assessment penalty"
   def titleWithSuffix(title: String): String = title + s" - Appeal a Self Assessment penalty - GOV.UK"
   val continue = "Continue"
@@ -39,9 +40,11 @@ sealed trait i18n {
 trait En extends i18n {
   override val lang: Language = language.En
 }
+object English extends En
 
 trait Cy extends i18n {
-  override def caption(from: String, to: String) = s"Late submission penalty point: $from to $to (Welsh)"
+  override def lspCaption(from: String, to: String) = s"Late submission penalty point: $from\u00A0to\u00A0$to (Welsh)"
+  override def lppCaption(from: String, to: String) = s"Late payment penalty: $from\u00A0to\u00A0$to (Welsh)"
   override val serviceName = "Appeal a Self Assessment penalty (Welsh)"
   override def titleWithSuffix(title: String): String = title + s" - Appeal a Self Assessment penalty - GOV.UK (Welsh)"
   override val continue = "Yn eich blaen"
@@ -56,3 +59,4 @@ trait Cy extends i18n {
   override val year = "blwyddyn"
   override val lang: Language = language.Cy
 }
+object Welsh extends Cy

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/BaseUserAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/BaseUserAnswersControllerSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 
+import fixtures.BaseFixtures
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -34,7 +35,7 @@ import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class BaseUserAnswersControllerSpec extends AnyWordSpec with should.Matchers with GuiceOneAppPerSuite with LogCapturing {
+class BaseUserAnswersControllerSpec extends AnyWordSpec with should.Matchers with GuiceOneAppPerSuite with LogCapturing with BaseFixtures {
 
   implicit lazy val ec: ExecutionContext = ExecutionContext.global
   lazy val errHandler: ErrorHandler = app.injector.instanceOf[ErrorHandler]
@@ -56,7 +57,8 @@ class BaseUserAnswersControllerSpec extends AnyWordSpec with should.Matchers wit
 
         implicit val user: CurrentUserRequestWithAnswers[_] = CurrentUserRequestWithAnswers(
           mtdItId = "123456789",
-          userAnswers = UserAnswers("1234").setAnswer(testPage, "foo")
+          userAnswers = UserAnswers("1234").setAnswer(testPage, "foo"),
+          penaltyData = penaltyDataLSP
         )(FakeRequest())
 
         "execute the function with that answer" in {
@@ -72,7 +74,8 @@ class BaseUserAnswersControllerSpec extends AnyWordSpec with should.Matchers wit
 
         implicit val user: CurrentUserRequestWithAnswers[_] = CurrentUserRequestWithAnswers(
           mtdItId = "123456789",
-          userAnswers = UserAnswers("1234")
+          userAnswers = UserAnswers("1234"),
+          penaltyData = penaltyDataLSP
         )(FakeRequest())
 
         //TODO: In future, redirect to SessionTimeout, or JourneyExpired page???

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/predicates/UserAnswersActionSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/predicates/UserAnswersActionSpec.scala
@@ -26,7 +26,6 @@ import play.api.mvc.{AnyContent, Request, Result}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.{AppConfig, ErrorHandler}
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.MultiplePenaltiesData
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{CurrentUserRequest, CurrentUserRequestWithAnswers, PenaltyData}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.mocks.MockSessionService

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/WhenDidEventHappenFormSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/WhenDidEventHappenFormSpec.scala
@@ -64,7 +64,7 @@ class WhenDidEventHappenFormSpec extends AnyWordSpec with should.Matchers with G
 
                   "testing content for scenario where Client didn't get information to the agent in time" should {
 
-                    val userAnswers = emptyUserAnswers
+                    val userAnswers = emptyUerAnswersWithLSP
                       .setAnswer(WhoPlannedToSubmitPage, AgentClientEnum.agent)
                       .setAnswer(WhatCausedYouToMissDeadlinePage, AgentClientEnum.client)
 
@@ -86,7 +86,7 @@ class WhenDidEventHappenFormSpec extends AnyWordSpec with should.Matchers with G
                   }
                 } else { //Reason is 'other' BUT User is NOT an Agent
 
-                  implicit val user: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers)
+                  implicit val user: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUerAnswersWithLSP)
 
                   val infix = if(isLPP) ".lpp" else ".lsp"
 
@@ -104,7 +104,7 @@ class WhenDidEventHappenFormSpec extends AnyWordSpec with should.Matchers with G
                 }
               } else { //Reason is NOT 'other'
 
-                implicit val user: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers)
+                implicit val user: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUerAnswersWithLSP)
 
                 behave like dateForm(
                   form = WhenDidEventHappenForm.form(reason, isLPP),

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswersSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswersSpec.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models
+
+import fixtures.BaseFixtures
+import org.mockito.Mockito.when
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar.mock
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.mvc.AnyContent
+import play.api.test.FakeRequest
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{CrimeReportedPage, HonestyDeclarationPage, ReasonableExcusePage, WhenDidEventHappenPage}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{IncomeTaxSessionKeys, TimeMachine}
+
+import java.time.LocalDate
+
+class CurrentUserRequestWithAnswersSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with BaseFixtures {
+
+  implicit lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  implicit lazy val mockTimeMachine: TimeMachine = mock[TimeMachine]
+
+  "isAppealLate" should {
+
+    class Setup(date: LocalDate) {
+      when(mockTimeMachine.getCurrentDate).thenReturn(date)
+    }
+
+    val fakeRequestForAppealingBothPenalties: (LocalDate, LocalDate) => CurrentUserRequestWithAnswers[AnyContent] = (lpp1Date: LocalDate, lpp2Date: LocalDate) => {
+
+      val penaltyData = PenaltyData(
+        penaltyNumber = "123456789",
+        appealData = latePaymentAppealData,
+        multiplePenaltiesData = Some(multiplePenaltiesModel.copy(
+          firstPenaltyCommunicationDate = lpp1Date,
+          secondPenaltyCommunicationDate = lpp2Date
+        ))
+      )
+
+      CurrentUserRequestWithAnswers(
+        mtdItId = testMtdItId,
+        userAnswers = emptyUerAnswersWithLSP
+          .setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyData)
+          .setAnswer(HonestyDeclarationPage, true)
+          .setAnswer(CrimeReportedPage, CrimeReportedEnum.yes)
+          .setAnswer(ReasonableExcusePage, "crime")
+          .setAnswer(WhenDidEventHappenPage, LocalDate.of(2022, 1, 1)),
+        penaltyData = penaltyData
+      )(FakeRequest().withSession(
+        //TODO: This will be moved to be a UserAnswer when the page is built
+        IncomeTaxSessionKeys.doYouWantToAppealBothPenalties -> "yes")
+      )
+    }
+
+    val fakeRequestForAppealingSinglePenalty: LocalDate => CurrentUserRequestWithAnswers[AnyContent] = (date: LocalDate) => {
+
+      val penaltyData = PenaltyData(
+        penaltyNumber = "123456789",
+        appealData = latePaymentAppealData.copy(dateCommunicationSent = date),
+        multiplePenaltiesData = None
+      )
+
+      CurrentUserRequestWithAnswers(
+        mtdItId = testMtdItId,
+        userAnswers = emptyUerAnswersWithLSP
+          .setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyData)
+          .setAnswer(HonestyDeclarationPage, true)
+          .setAnswer(CrimeReportedPage, CrimeReportedEnum.yes)
+          .setAnswer(ReasonableExcusePage, "crime")
+          .setAnswer(WhenDidEventHappenPage, LocalDate.of(2022, 1, 1)),
+        penaltyData = penaltyData
+      )(FakeRequest())
+    }
+
+    "return true" when {
+      "communication date of penalty > 30 days ago" in new Setup(LocalDate.of(2022, 1, 1)) {
+        fakeRequestForAppealingSinglePenalty(LocalDate.of(2021, 12, 1)).isAppealLate() shouldBe true
+      }
+
+      "appealing both penalties and LPP1 is late" in new Setup(LocalDate.of(2022, 1, 1)) {
+        fakeRequestForAppealingBothPenalties(LocalDate.of(2021, 12, 1), LocalDate.of(2022, 1, 1)).isAppealLate() shouldBe true
+      }
+
+      "appealing both penalties and both are late" in new Setup(LocalDate.of(2022, 4, 1)) {
+        fakeRequestForAppealingBothPenalties(LocalDate.of(2021, 12, 1), LocalDate.of(2022, 1, 1)).isAppealLate() shouldBe true
+      }
+    }
+
+    "return false" when {
+      "communication date of penalty < 30 days ago" in new Setup(LocalDate.of(2022, 1, 1)) {
+        fakeRequestForAppealingSinglePenalty(LocalDate.of(2021, 12, 31)).isAppealLate() shouldBe false
+      }
+
+      "appealing both penalties and LPP1 and LPP2 are not late" in new Setup(LocalDate.of(2022, 1, 1)) {
+        fakeRequestForAppealingBothPenalties(LocalDate.of(2021, 12, 31), LocalDate.of(2021, 12, 31)).isAppealLate() shouldBe false
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealServiceSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealServiceSpec.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services
 
 import fixtures.FileUploadFixtures
-import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchers.{eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.scalatest.matchers.should.Matchers
@@ -36,7 +35,6 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.connectors.httpParsers.{Inv
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models._
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.submission.OtherAppealInformation
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.{AppealSubmission, AppealSubmissionResponseModel, MultiplePenaltiesData}
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.session.UserAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{CrimeReportedPage, HonestyDeclarationPage, ReasonableExcusePage, WhenDidEventHappenPage}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.mocks.MockUpscanService
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/CrimeReportedSummarySpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/CrimeReportedSummarySpec.scala
@@ -57,7 +57,7 @@ class CrimeReportedSummarySpec extends AnyWordSpec with Matchers with GuiceOneAp
             if (reason != "crime") {
 
               "return None" in {
-                implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers.setAnswer(ReasonableExcusePage, reason))
+                implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, reason))
                 CrimeReportedSummary.row() shouldBe None
               }
 
@@ -66,7 +66,7 @@ class CrimeReportedSummarySpec extends AnyWordSpec with Matchers with GuiceOneAp
               "when there's no answer" should {
 
                 "return None" in {
-                  implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers.setAnswer(ReasonableExcusePage, reason))
+                  implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, reason))
                   CrimeReportedSummary.row() shouldBe None
                 }
               }
@@ -76,7 +76,7 @@ class CrimeReportedSummarySpec extends AnyWordSpec with Matchers with GuiceOneAp
                 "must output the expected row" in {
 
                   implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(
-                    emptyUserAnswers
+                    emptyUerAnswersWithLSP
                       .setAnswer(ReasonableExcusePage, reason)
                       .setAnswer(CrimeReportedPage, CrimeReportedEnum.yes)
                   )

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/LateAppealSummarySpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/LateAppealSummarySpec.scala
@@ -48,7 +48,7 @@ class LateAppealSummarySpec extends AnyWordSpec with Matchers with GuiceOneAppPe
         "when there's no answer" should {
 
           "return None" in {
-            implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers)
+            implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUerAnswersWithLSP)
             lateAppealSummary.row() shouldBe None
           }
         }
@@ -60,7 +60,7 @@ class LateAppealSummarySpec extends AnyWordSpec with Matchers with GuiceOneAppPe
             "must output the expected row with the extended late appeal days value" in {
 
               implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(
-                emptyUserAnswers
+                emptyUerAnswersWithLSP
                   .setAnswer(ReasonableExcusePage, "bereavement")
                   .setAnswer(LateAppealPage, "foo")
               )
@@ -86,7 +86,7 @@ class LateAppealSummarySpec extends AnyWordSpec with Matchers with GuiceOneAppPe
             "must output the expected row with the standard late appeal days" in {
 
               implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(
-                emptyUserAnswers
+                emptyUerAnswersWithLSP
                   .setAnswer(ReasonableExcusePage, "crime")
                   .setAnswer(LateAppealPage, "foo")
               )

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/ReasonableExcuseSummarySpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/ReasonableExcuseSummarySpec.scala
@@ -57,7 +57,7 @@ class ReasonableExcuseSummarySpec extends AnyWordSpec with Matchers with GuiceOn
             "when there's no answer" should {
 
               "return None" in {
-                implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers)
+                implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUerAnswersWithLSP)
                 ReasonableExcuseSummary.row() shouldBe None
               }
             }
@@ -67,7 +67,7 @@ class ReasonableExcuseSummarySpec extends AnyWordSpec with Matchers with GuiceOn
               "must output the expected row" in {
 
                 implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(
-                  emptyUserAnswers.setAnswer(ReasonableExcusePage, reason)
+                  emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, reason)
                 )
 
                 ReasonableExcuseSummary.row() shouldBe Some(summaryListRow(

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/UploadedDocumentsSummarySpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/UploadedDocumentsSummarySpec.scala
@@ -36,7 +36,7 @@ class UploadedDocumentsSummarySpec extends AnyWordSpec with Matchers with GuiceO
   lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
   lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
 
-  implicit lazy val user: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers.setAnswer(ReasonableExcusePage, "other"))
+  implicit lazy val user: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, "other"))
 
   "UploadedDocumentsSummary" when {
 

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/WhatCausedYouToMissDeadlineSummarySpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/WhatCausedYouToMissDeadlineSummarySpec.scala
@@ -45,7 +45,7 @@ class WhatCausedYouToMissDeadlineSummarySpec extends AnyWordSpec with Matchers w
         "when the request is not for an Agent (even if there's an answer saved)" should {
 
           "return None" in {
-            implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers.setAnswer(WhatCausedYouToMissDeadlinePage, AgentClientEnum.agent))
+            implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUerAnswersWithLSP.setAnswer(WhatCausedYouToMissDeadlinePage, AgentClientEnum.agent))
             WhatCausedYouToMissDeadlineSummary.row() shouldBe None
           }
         }
@@ -53,7 +53,7 @@ class WhatCausedYouToMissDeadlineSummarySpec extends AnyWordSpec with Matchers w
         "when there's no answer" should {
 
           "return None" in {
-            implicit val request: CurrentUserRequestWithAnswers[_] = agentUserRequestWithAnswers(emptyUserAnswers)
+            implicit val request: CurrentUserRequestWithAnswers[_] = agentUserRequestWithAnswers(emptyUerAnswersWithLSP)
             WhatCausedYouToMissDeadlineSummary.row() shouldBe None
           }
         }
@@ -63,7 +63,7 @@ class WhatCausedYouToMissDeadlineSummarySpec extends AnyWordSpec with Matchers w
           "must output the expected row" in {
 
             implicit val request: CurrentUserRequestWithAnswers[_] = agentUserRequestWithAnswers(
-              emptyUserAnswers.setAnswer(WhatCausedYouToMissDeadlinePage, AgentClientEnum.agent)
+              emptyUerAnswersWithLSP.setAnswer(WhatCausedYouToMissDeadlinePage, AgentClientEnum.agent)
             )
 
             WhatCausedYouToMissDeadlineSummary.row() shouldBe Some(summaryListRow(

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/WhenDidEventEndSummarySpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/WhenDidEventEndSummarySpec.scala
@@ -60,7 +60,7 @@ class WhenDidEventEndSummarySpec extends AnyWordSpec with Matchers with GuiceOne
             "when there's no answer" should {
 
               "return None" in {
-                implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers)
+                implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUerAnswersWithLSP)
                 WhenDidEventEndSummary.row() shouldBe None
               }
             }
@@ -72,7 +72,7 @@ class WhenDidEventEndSummarySpec extends AnyWordSpec with Matchers with GuiceOne
                 "must output the expected row" in {
 
                   implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(
-                    emptyUserAnswers
+                    emptyUerAnswersWithLSP
                       .setAnswer(ReasonableExcusePage, reason)
                       .setAnswer(WhenDidEventEndPage, LocalDate.of(2025, 1, 1))
                   )
@@ -95,7 +95,7 @@ class WhenDidEventEndSummarySpec extends AnyWordSpec with Matchers with GuiceOne
 
                 "return None" in {
                   implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(
-                    emptyUserAnswers
+                    emptyUerAnswersWithLSP
                       .setAnswer(ReasonableExcusePage, reason)
                       .setAnswer(WhenDidEventEndPage, LocalDate.of(2025, 1, 1))
                   )

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/WhenDidEventHappenSummarySpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/WhenDidEventHappenSummarySpec.scala
@@ -60,7 +60,7 @@ class WhenDidEventHappenSummarySpec extends AnyWordSpec with Matchers with Guice
             "when there's no answer" should {
 
               "return None" in {
-                implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers)
+                implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUerAnswersWithLSP)
                 WhenDidEventHappenSummary.row() shouldBe None
               }
             }
@@ -70,7 +70,7 @@ class WhenDidEventHappenSummarySpec extends AnyWordSpec with Matchers with Guice
               "must output the expected row" in {
 
                 implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(
-                  emptyUserAnswers
+                  emptyUerAnswersWithLSP
                     .setAnswer(ReasonableExcusePage, reason)
                     .setAnswer(WhenDidEventHappenPage, LocalDate.of(2025, 1, 1))
                 )

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/WhoPlannedToSubmitSummarySpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/WhoPlannedToSubmitSummarySpec.scala
@@ -45,7 +45,7 @@ class WhoPlannedToSubmitSummarySpec extends AnyWordSpec with Matchers with Guice
         "when the request is not for an Agent (even if there's an answer saved)" should {
 
           "return None" in {
-            implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers.setAnswer(WhoPlannedToSubmitPage, AgentClientEnum.agent))
+            implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUerAnswersWithLSP.setAnswer(WhoPlannedToSubmitPage, AgentClientEnum.agent))
             WhoPlannedToSubmitSummary.row() shouldBe None
           }
         }
@@ -53,7 +53,7 @@ class WhoPlannedToSubmitSummarySpec extends AnyWordSpec with Matchers with Guice
         "when there's no answer" should {
 
           "return None" in {
-            implicit val request: CurrentUserRequestWithAnswers[_] = agentUserRequestWithAnswers(emptyUserAnswers)
+            implicit val request: CurrentUserRequestWithAnswers[_] = agentUserRequestWithAnswers(emptyUerAnswersWithLSP)
             WhoPlannedToSubmitSummary.row() shouldBe None
           }
         }
@@ -63,7 +63,7 @@ class WhoPlannedToSubmitSummarySpec extends AnyWordSpec with Matchers with Guice
           "must output the expected row" in {
 
             implicit val request: CurrentUserRequestWithAnswers[_] = agentUserRequestWithAnswers(
-              emptyUserAnswers.setAnswer(WhoPlannedToSubmitPage, AgentClientEnum.agent)
+              emptyUerAnswersWithLSP.setAnswer(WhoPlannedToSubmitPage, AgentClientEnum.agent)
             )
 
             WhoPlannedToSubmitSummary.row() shouldBe Some(summaryListRow(

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/helpers/CheckAnswersHelperSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/helpers/CheckAnswersHelperSpec.scala
@@ -48,7 +48,7 @@ class CheckAnswersHelperSpec extends AnyWordSpec with Matchers with GuiceOneAppP
 
           val uploads = Seq(callbackModel, callbackModel2)
 
-          val userAnswers = emptyUserAnswers
+          val userAnswers = emptyUerAnswersWithLSP
             .setAnswer(WhoPlannedToSubmitPage, AgentClientEnum.agent)
             .setAnswer(WhatCausedYouToMissDeadlinePage, AgentClientEnum.client)
             .setAnswer(ReasonableExcusePage, "health")

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsFileUploadViewSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsFileUploadViewSpec.scala
@@ -22,10 +22,9 @@ import fixtures.messages.upscan.NonJsFileUploadMessages
 import fixtures.views.BaseSelectors
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Lang, Messages, MessagesApi}
-import play.api.mvc.Request
-import play.api.test.FakeRequest
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan.UploadDocumentForm
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewBehaviours
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.upscan.NonJsFileUploadView
 
@@ -35,7 +34,7 @@ class NonJsFileUploadViewSpec extends ViewBehaviours with GuiceOneAppPerSuite wi
   lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
 
   implicit lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
-  implicit lazy val request: Request[_] = FakeRequest()
+  implicit lazy val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers)
 
   object Selectors extends BaseSelectors
 

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsRemoveFileViewSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsRemoveFileViewSpec.scala
@@ -21,11 +21,10 @@ import fixtures.messages.upscan.NonJsRemoveFileMessages
 import fixtures.views.BaseSelectors
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Lang, Messages, MessagesApi}
-import play.api.mvc.Request
-import play.api.test.FakeRequest
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan.UploadDocumentForm
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.UploadedFilesViewModel
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewBehaviours
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.upscan.NonJsRemoveFileView
@@ -36,7 +35,7 @@ class NonJsRemoveFileViewSpec extends ViewBehaviours with GuiceOneAppPerSuite wi
   lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
 
   implicit lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
-  implicit lazy val request: Request[_] = FakeRequest()
+  implicit lazy val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers)
 
   object Selectors extends BaseSelectors
 

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsUploadCheckAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsUploadCheckAnswersViewSpec.scala
@@ -21,11 +21,10 @@ import fixtures.messages.upscan.NonJsUploadCheckAnswersMessages
 import fixtures.views.BaseSelectors
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Lang, Messages, MessagesApi}
-import play.api.mvc.Request
-import play.api.test.FakeRequest
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan.UploadDocumentForm
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.UploadedFilesViewModel
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewBehaviours
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.upscan.NonJsUploadCheckAnswersView
@@ -36,7 +35,7 @@ class NonJsUploadCheckAnswersViewSpec extends ViewBehaviours with GuiceOneAppPer
   lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
 
   implicit lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
-  implicit lazy val request: Request[_] = FakeRequest()
+  implicit lazy val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUserAnswers)
 
   object Selectors extends BaseSelectors
 


### PR DESCRIPTION
Notes:
- There's small amount of scope creep on this ticket, because now we have the Penalty Data there was some hard-coded values in views which made sense to be calculated or worked out. Mainly these two fields:
   - `isLPP` - this is now determined from PenaltyType
   - `isLate` - this is now calculated based on the existing calculation that was in the AppealService (although, this has been moved to `CurrentUserRequestWithAnswers` model so that it can be available to all Controllers as needed without calling the Service.