### PR TITLE
[MIPR-1595] Add the "Upload Extra Evidence" summray row to the CYA and Print view

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/ExtraEvidenceSummary.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/ExtraEvidenceSummary.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.checkAnswers
+
+import play.api.i18n.Messages
+import play.twirl.api.Html
+import uk.gov.hmrc.govukfrontend.views.Aliases.{ActionItem, Text}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Actions, SummaryListRow}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.ReasonableExcuse.Other
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{ExtraEvidencePage, ReasonableExcusePage}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.helpers.SummaryListRowHelper
+
+object ExtraEvidenceSummary extends SummaryListRowHelper {
+
+  def row(showActionLinks: Boolean = true)(implicit user: CurrentUserRequestWithAnswers[_], messages: Messages): Option[SummaryListRow] =
+    Option.when(ReasonableExcusePage.value.contains(Other)) {
+      ExtraEvidencePage.value.map { extraEvidence =>
+        summaryListRow(
+          label = messages("checkYourAnswers.extraEvidence.key"),
+          value = Html(messages(s"common.${if(extraEvidence) "yes" else "no"}")),
+          actions = Option.when(showActionLinks)(Actions(
+            items = Seq(
+              ActionItem(
+                content = Text(messages("common.change")),
+                href = controllers.routes.ExtraEvidenceController.onPageLoad().url,
+                visuallyHiddenText = Some(messages("checkYourAnswers.extraEvidence.change.hidden"))
+              ).withId("changeExtraEvidence")
+            ))
+          )
+        )
+      }
+    }.flatten
+
+}

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/helpers/CheckAnswersHelper.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/helpers/CheckAnswersHelper.scala
@@ -36,6 +36,7 @@ class CheckAnswersHelper @Inject()(lateAppealSummary: LateAppealSummary) {
       CrimeReportedSummary.row(showActionLinks),
       MissedDeadlineReasonSummary.row(showActionLinks),
       lateAppealSummary.row(showActionLinks),
+      ExtraEvidenceSummary.row(showActionLinks),
       UploadedDocumentsSummary.row(uploadedFiles, showActionLinks)
     ).flatten
 }

--- a/conf/messages
+++ b/conf/messages
@@ -316,6 +316,9 @@ checkYourAnswers.declaration.h2 = Declaration
 checkYourAnswers.declaration.text.1 = By submitting this appeal, you are making a legal declaration that the information is correct and complete to the best of your knowledge.
 checkYourAnswers.declaration.text.2 = A false declaration can result in prosecution.
 
+checkYourAnswers.extraEvidence.key = Do you want to upload evidence to support your appeal?
+checkYourAnswers.extraEvidence.change.hidden = do you want to upload evidence to support your appeal
+
 checkYourAnswers.acceptAndSend = Accept and send
 
 # Appeal Confirmation page

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -320,6 +320,9 @@ checkYourAnswers.declaration.h2 = Declaration (Welsh)
 checkYourAnswers.declaration.text.1 = By submitting this appeal, you are making a legal declaration that the information is correct and complete to the best of your knowledge. (Welsh)
 checkYourAnswers.declaration.text.2 = A false declaration can result in prosecution. (Welsh)
 
+checkYourAnswers.extraEvidence.key = Do you want to upload evidence to support your appeal? (Welsh)
+checkYourAnswers.extraEvidence.change.hidden = do you want to upload evidence to support your appeal (Welsh)
+
 checkYourAnswers.acceptAndSend = Accept and send (Welsh)
 
 # View appeal details page

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ViewAppealDetailsControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ViewAppealDetailsControllerISpec.scala
@@ -74,7 +74,8 @@ class ViewAppealDetailsControllerISpec extends ComponentSpecHelper with ViewSpec
           WhenDidEventHappenMessages.English,
           LateAppealMessages.English,
           UploadedDocumentsSummaryMessages.English,
-          MissedDeadlineReasonMessages.English
+          MissedDeadlineReasonMessages.English,
+          ExtraEvidenceMessages.English
         ),
         (
           PrintAppealMessages.Welsh,
@@ -84,7 +85,8 @@ class ViewAppealDetailsControllerISpec extends ComponentSpecHelper with ViewSpec
           WhenDidEventHappenMessages.Welsh,
           LateAppealMessages.Welsh,
           UploadedDocumentsSummaryMessages.Welsh,
-          MissedDeadlineReasonMessages.Welsh
+          MissedDeadlineReasonMessages.Welsh,
+          ExtraEvidenceMessages.Welsh
         )
       ).foreach { case (
         messagesForLanguage,
@@ -94,7 +96,8 @@ class ViewAppealDetailsControllerISpec extends ComponentSpecHelper with ViewSpec
         whenEventHappenedMessages,
         lateAppealMessages,
         fileUploadMessages,
-        missedDeadlineMessages) =>
+        missedDeadlineMessages,
+        extraEvidenceMessages) =>
 
         implicit val messages: Messages = messagesApi.preferred(Seq(Lang(messagesForLanguage.lang.code)))
 
@@ -211,8 +214,10 @@ class ViewAppealDetailsControllerISpec extends ComponentSpecHelper with ViewSpec
                   document.select(Selectors.summaryRowValue(7)).text() shouldBe dateToString(LocalDate.of(2025, 2, 1), withNBSP = false)
                   document.select(Selectors.summaryRowKey(8)).text() shouldBe missedDeadlineMessages.cyaKey(isLPP = false)
                   document.select(Selectors.summaryRowValue(8)).text() shouldBe "Forgot"
-                  document.select(Selectors.summaryRowKey(9)).text() shouldBe fileUploadMessages.cyaKey
-                  document.select(Selectors.summaryRowValue(9)).text() shouldBe "file1.txt file2.txt"
+                  document.select(Selectors.summaryRowKey(9)).text() shouldBe extraEvidenceMessages.cyaKey
+                  document.select(Selectors.summaryRowValue(9)).text() shouldBe extraEvidenceMessages.yes
+                  document.select(Selectors.summaryRowKey(10)).text() shouldBe fileUploadMessages.cyaKey
+                  document.select(Selectors.summaryRowValue(10)).text() shouldBe "file1.txt file2.txt"
 
                 } else {
                   document.select(Selectors.summaryRowKey(4)).text() shouldBe reasonableExcuseMessages.cyaKey
@@ -221,8 +226,10 @@ class ViewAppealDetailsControllerISpec extends ComponentSpecHelper with ViewSpec
                   document.select(Selectors.summaryRowValue(5)).text() shouldBe dateToString(LocalDate.of(2025, 2, 1), withNBSP = false)
                   document.select(Selectors.summaryRowKey(6)).text() shouldBe missedDeadlineMessages.cyaKey(isLPP = false)
                   document.select(Selectors.summaryRowValue(6)).text() shouldBe "Forgot"
-                  document.select(Selectors.summaryRowKey(7)).text() shouldBe fileUploadMessages.cyaKey
-                  document.select(Selectors.summaryRowValue(7)).text() shouldBe "file1.txt file2.txt"
+                  document.select(Selectors.summaryRowKey(7)).text() shouldBe extraEvidenceMessages.cyaKey
+                  document.select(Selectors.summaryRowValue(7)).text() shouldBe extraEvidenceMessages.yes
+                  document.select(Selectors.summaryRowKey(8)).text() shouldBe fileUploadMessages.cyaKey
+                  document.select(Selectors.summaryRowValue(8)).text() shouldBe "file1.txt file2.txt"
                 }
               }
             }

--- a/test-fixtures/fixtures/messages/ExtraEvidenceMessages.scala
+++ b/test-fixtures/fixtures/messages/ExtraEvidenceMessages.scala
@@ -23,7 +23,7 @@ object ExtraEvidenceMessages {
     val errorInvalid = "Tell us if you want to upload evidence"
 
     val cyaKey = "Do you want to upload evidence to support your appeal?"
-    val cyaHidden = "do you want to upload evidence to support your appeal?"
+    val cyaHidden = "do you want to upload evidence to support your appeal"
   }
 
   object English extends Messages with En
@@ -33,6 +33,6 @@ object ExtraEvidenceMessages {
     override val errorInvalid = "Tell us if you want to upload evidence (Welsh)"
 
     override val cyaKey = "Do you want to upload evidence to support your appeal? (Welsh)"
-    override val cyaHidden = "do you want to upload evidence to support your appeal? (Welsh)"
+    override val cyaHidden = "do you want to upload evidence to support your appeal (Welsh)"
   }
 }

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/ExtraEvidenceSummarySpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/viewmodels/checkAnswers/ExtraEvidenceSummarySpec.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.checkAnswers
+
+import fixtures.BaseFixtures
+import fixtures.messages.ExtraEvidenceMessages
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import play.twirl.api.Html
+import uk.gov.hmrc.govukfrontend.views.Aliases.{ActionItem, Text}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.Actions
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.ReasonableExcuse.Other
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{CurrentUserRequestWithAnswers, ReasonableExcuse}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages.{ExtraEvidencePage, ReasonableExcusePage}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.helpers.SummaryListRowHelper
+
+class ExtraEvidenceSummarySpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with BaseFixtures with SummaryListRowHelper {
+
+  lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+
+  "ExtraEvidenceSummary" when {
+
+    ReasonableExcuse.allReasonableExcuses.foreach { reason =>
+
+      s"for reasonableExcuse '$reason'" when {
+
+        Seq(ExtraEvidenceMessages.English, ExtraEvidenceMessages.Welsh).foreach { messagesForLanguage =>
+
+          s"being rendered in lang name '${messagesForLanguage.lang.name}'" when {
+
+            implicit val msgs: Messages = messagesApi.preferred(Seq(Lang(messagesForLanguage.lang.code)))
+
+            if (reason != Other) {
+
+              "return None" in {
+                implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, reason))
+                ExtraEvidenceSummary.row() shouldBe None
+              }
+
+            } else {
+
+              "there's no answer" should {
+
+                "return None" in {
+                  implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(emptyUerAnswersWithLSP.setAnswer(ReasonableExcusePage, reason))
+                  ExtraEvidenceSummary.row() shouldBe None
+                }
+              }
+
+              "there's an answer" when {
+
+                "show action links is set to true" should {
+
+                  "must output the expected row with a change link" in {
+
+                    implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(
+                      emptyUerAnswersWithLSP
+                        .setAnswer(ReasonableExcusePage, reason)
+                        .setAnswer(ExtraEvidencePage, true)
+                    )
+
+                    ExtraEvidenceSummary.row() shouldBe Some(summaryListRow(
+                      label = messagesForLanguage.cyaKey,
+                      value = Html(messagesForLanguage.yes),
+                      actions = Some(Actions(
+                        items = Seq(
+                          ActionItem(
+                            content = Text(messagesForLanguage.change),
+                            href = controllers.routes.ExtraEvidenceController.onPageLoad().url,
+                            visuallyHiddenText = Some(messagesForLanguage.cyaHidden)
+                          ).withId("changeExtraEvidence")
+                        )
+                      ))
+                    ))
+                  }
+                }
+
+                "show action links is set to false" should {
+
+                  "must output the expected row WITHOUT a change link" in {
+
+                    implicit val request: CurrentUserRequestWithAnswers[_] = userRequestWithAnswers(
+                      emptyUerAnswersWithLSP
+                        .setAnswer(ReasonableExcusePage, reason)
+                        .setAnswer(ExtraEvidencePage, true)
+                    )
+
+                    ExtraEvidenceSummary.row(showActionLinks = false) shouldBe Some(summaryListRow(
+                      label = messagesForLanguage.cyaKey,
+                      value = Html(messagesForLanguage.yes),
+                      actions = None
+                    ))
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/helpers/CheckAnswersHelperSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/helpers/CheckAnswersHelperSpec.scala
@@ -70,6 +70,7 @@ class CheckAnswersHelperSpec extends AnyWordSpec with Matchers with GuiceOneAppP
               CrimeReportedSummary.row(),
               MissedDeadlineReasonSummary.row(),
               lateAppealSummary.row(),
+              ExtraEvidenceSummary.row(),
               UploadedDocumentsSummary.row(uploads)
             ).flatten
           }
@@ -88,6 +89,7 @@ class CheckAnswersHelperSpec extends AnyWordSpec with Matchers with GuiceOneAppP
               CrimeReportedSummary.row(showActionLinks = false),
               MissedDeadlineReasonSummary.row(showActionLinks = false),
               lateAppealSummary.row(showActionLinks = false),
+              ExtraEvidenceSummary.row(showActionLinks = false),
               UploadedDocumentsSummary.row(uploads, showActionLinks = false)
             ).flatten
           }


### PR DESCRIPTION
- This was something that Nadin spotted which we had missed, to add the row in for the Upload Extra Evidence page to the CYA - otherwise, there's no way of changing from 'Yes' to 'No' or vice-versa for uploading evidence.