### PR TITLE
[MIPR-1597] Add query param to store if this is a 2nd stage appeal journey

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/PenaltyData.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/PenaltyData.scala
@@ -20,6 +20,7 @@ import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.appeals.MultiplePenaltiesData
 
 case class PenaltyData(penaltyNumber: String,
+                       is2ndStageAppeal: Boolean,
                        appealData: AppealData,
                        multiplePenaltiesData: Option[MultiplePenaltiesData]) {
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -11,7 +11,7 @@ GET        /language/:lang                  uk.gov.hmrc.incometaxpenaltiesappeal
 
 #Initialise appeal and start page
 GET        /appeal-start                    uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.AppealStartController.onPageLoad()
-GET        /initialise-appeal               uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.InitialisationController.onPageLoad(penaltyId: String, isLPP: Boolean, isAdditional: Boolean)
+GET        /initialise-appeal               uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.InitialisationController.onPageLoad(penaltyId: String, isLPP: Boolean, isAdditional: Boolean, is2ndStageAppeal: Boolean ?= false)
 
 #Reasonable excuse list
 GET        /reason-for-missing-deadline     uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.ReasonableExcuseController.onPageLoad()

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationControllerISpec.scala
@@ -56,12 +56,12 @@ class InitialisationControllerISpec extends ComponentSpecHelper with ViewSpecHel
   "GET /initialise-appeal" when {
     "penalty appeal data is successfully returned from penalties BE" when {
       "initialise the UserAnswers and redirect to the /appeal-start page, adding the journeyId to session" when {
-        "the user is an authorised individual" in {
+        "the user is an authorised individual (is2ndStageAppeal==false)" in {
 
           stubAuth(OK, successfulIndividualAuthResponse)
           successfulGetAppealDataResponse(penaltyDataLSP.penaltyNumber, testMtdItId)
 
-          val result = get(s"/initialise-appeal?penaltyId=${penaltyDataLSP.penaltyNumber}&isLPP=false&isAdditional=false")
+          val result = get(s"/initialise-appeal?penaltyId=${penaltyDataLSP.penaltyNumber}&isLPP=false&isAdditional=false&is2ndStageAppeal=false")
 
           result.status shouldBe SEE_OTHER
           result.header("Location") shouldBe Some(routes.AppealStartController.onPageLoad().url)
@@ -72,6 +72,7 @@ class InitialisationControllerISpec extends ComponentSpecHelper with ViewSpecHel
             data = Json.obj(
               IncomeTaxSessionKeys.penaltyData -> Json.obj(
                 "penaltyNumber" -> penaltyDataLSP.penaltyNumber,
+                "is2ndStageAppeal" -> false,
                 "appealData" -> Json.obj(
                   "type" -> PenaltyTypeEnum.Late_Submission,
                   "startDate" -> LocalDate.of(2020, 1, 1),
@@ -85,13 +86,13 @@ class InitialisationControllerISpec extends ComponentSpecHelper with ViewSpecHel
           ))
         }
 
-        "the user is an authorised agent (and LPP with multiple)" in {
+        "the user is an authorised agent (and LPP with multiple) (is2ndStageAppeal==true)" in {
 
           stubAuth(OK, successfulAgentAuthResponse)
           successfulGetAppealDataResponse(penaltyDataLPP.penaltyNumber, testMtdItId, isLPP = true)
           successfulGetMultiplePenalties(penaltyDataLPP.penaltyNumber, testMtdItId)
 
-          val result = get(s"/initialise-appeal?penaltyId=${penaltyDataLPP.penaltyNumber}&isLPP=true&isAdditional=false", isAgent = true)
+          val result = get(s"/initialise-appeal?penaltyId=${penaltyDataLPP.penaltyNumber}&isLPP=true&isAdditional=false&is2ndStageAppeal=true", isAgent = true)
 
           result.status shouldBe SEE_OTHER
           result.header("Location") shouldBe Some(routes.AppealStartController.onPageLoad().url)
@@ -102,6 +103,7 @@ class InitialisationControllerISpec extends ComponentSpecHelper with ViewSpecHel
             data = Json.obj(
               IncomeTaxSessionKeys.penaltyData -> Json.obj(
                 "penaltyNumber" -> penaltyDataLPP.penaltyNumber,
+                "is2ndStageAppeal" -> true,
                 "appealData" -> Json.obj(
                   "type" -> PenaltyTypeEnum.Late_Payment,
                   "startDate" -> LocalDate.of(2020, 1, 1),

--- a/test-fixtures/fixtures/BaseFixtures.scala
+++ b/test-fixtures/fixtures/BaseFixtures.scala
@@ -74,12 +74,14 @@ trait BaseFixtures {
 
   val penaltyDataLSP: PenaltyData = PenaltyData(
     penaltyNumber = "123456789",
+    is2ndStageAppeal = false,
     appealData = lateSubmissionAppealData,
     multiplePenaltiesData = None
   )
 
   val penaltyDataLPP: PenaltyData = PenaltyData(
     penaltyNumber = "123456790",
+    is2ndStageAppeal = false,
     appealData = latePaymentAppealData,
     multiplePenaltiesData = None
   )
@@ -92,6 +94,7 @@ trait BaseFixtures {
 
     val penaltyData = PenaltyData(
       penaltyNumber = "123456789",
+      is2ndStageAppeal = false,
       appealData = lateSubmissionAppealData,
       multiplePenaltiesData = None
     )
@@ -116,6 +119,7 @@ trait BaseFixtures {
 
     val penaltyData = PenaltyData(
       penaltyNumber = "123456789",
+      is2ndStageAppeal = false,
       appealData = latePaymentAppealData,
       multiplePenaltiesData = Some(multiplePenaltiesModel)
     )
@@ -140,6 +144,7 @@ trait BaseFixtures {
 
     val penaltyData = PenaltyData(
       penaltyNumber = "123456789",
+      is2ndStageAppeal = false,
       appealData = lateSubmissionAppealData,
       multiplePenaltiesData = None
     )
@@ -165,6 +170,7 @@ trait BaseFixtures {
 
     val penaltyData = PenaltyData(
       penaltyNumber = "123456789",
+      is2ndStageAppeal = false,
       appealData = lateSubmissionAppealData,
       multiplePenaltiesData = None
     )

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswersSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswersSpec.scala
@@ -46,6 +46,7 @@ class CurrentUserRequestWithAnswersSpec extends AnyWordSpec with Matchers with G
 
       val penaltyData = PenaltyData(
         penaltyNumber = "123456789",
+        is2ndStageAppeal = false,
         appealData = latePaymentAppealData,
         multiplePenaltiesData = Some(multiplePenaltiesModel.copy(
           firstPenaltyCommunicationDate = lpp1Date,
@@ -72,6 +73,7 @@ class CurrentUserRequestWithAnswersSpec extends AnyWordSpec with Matchers with G
 
       val penaltyData = PenaltyData(
         penaltyNumber = "123456789",
+        is2ndStageAppeal = false,
         appealData = latePaymentAppealData.copy(dateCommunicationSent = date),
         multiplePenaltiesData = None
       )


### PR DESCRIPTION
This is an initial PR to add the `is2ndStageAppeal` query param and flag and store it against the PenaltyData in Mongo