### PR TITLE
[MIPR-1598] Updating routing for 2nd Stage Appeals journey

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/AppealStartController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/AppealStartController.scala
@@ -35,8 +35,14 @@ class AppealStartController @Inject()(appealStart: AppealStartView,
                                       override val controllerComponents: MessagesControllerComponents
                                      )(implicit timeMachine: TimeMachine, val appConfig: AppConfig) extends FrontendBaseController with I18nSupport with FeatureSwitching {
 
-  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers) { implicit currentUser =>
-    Ok(appealStart(currentUser.isAppealLate(), currentUser.isAgent))
+  def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers) { implicit user =>
+    Ok(appealStart(
+      user.isAppealLate(),
+      if(user.isAgent) {
+        routes.WhoPlannedToSubmitController.onPageLoad()
+      } else {
+        routes.ReasonableExcuseController.onPageLoad()
+      }
+    ))
   }
-
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/HonestyDeclarationController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/HonestyDeclarationController.scala
@@ -46,7 +46,11 @@ class HonestyDeclarationController @Inject()(honestyDeclaration: HonestyDeclarat
   def submit(): Action[AnyContent] = (authorised andThen withAnswers).async { implicit user =>
     val updatedAnswers = user.userAnswers.setAnswer(HonestyDeclarationPage, true)
     userAnswersService.updateAnswers(updatedAnswers).map { _ =>
-      Redirect(routes.WhenDidEventHappenController.onPageLoad())
+      Redirect(if(user.is2ndStageAppeal) {
+        routes.MissedDeadlineReasonController.onPageLoad()
+      } else {
+        routes.WhenDidEventHappenController.onPageLoad()
+      })
     }
   }
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ReasonableExcuseController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ReasonableExcuseController.scala
@@ -45,7 +45,13 @@ class ReasonableExcuseController @Inject()(reasonableExcuse: ReasonableExcuseVie
                                           )(implicit ec: ExecutionContext, val appConfig: AppConfig) extends BaseUserAnswersController {
 
   def onPageLoad(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>
-    renderView(Ok, fillForm(ReasonableExcusesForm.form(), ReasonableExcusePage))
+    if(user.penaltyData.is2ndStageAppeal) {
+      //TODO: This is the current working assumption, that 2nd Stage Appeals will be set to 'Other' by default.
+      //      However, an API change may be needed for this to make the Reasonable Excuse optional in the appeal submission
+      updateUserAnswersAndRedirect(Other)
+    } else {
+      renderView(Ok, fillForm(ReasonableExcusesForm.form(), ReasonableExcusePage))
+    }
   }
 
   def submit(): Action[AnyContent] = (authorised andThen withNavBar andThen withAnswers).async { implicit user =>

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswers.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswers.scala
@@ -45,6 +45,7 @@ case class CurrentUserRequestWithAnswers[A](mtdItId: String,
   val communicationSent: LocalDate = penaltyData.appealData.dateCommunicationSent
   val isLPP: Boolean = penaltyData.isLPP
   val isAdditional: Boolean = penaltyData.isAdditional
+  val is2ndStageAppeal: Boolean = penaltyData.is2ndStageAppeal
 
   //Multiple Penalties Data
   val firstPenaltyNumber: Option[String] = penaltyData.multiplePenaltiesData.map(_.firstPenaltyChargeReference)
@@ -66,12 +67,18 @@ case class CurrentUserRequestWithAnswers[A](mtdItId: String,
   def isAppealLate()(implicit timeMachine: TimeMachine, appConfig: AppConfig): Boolean = {
     val dateWhereLateAppealIsApplicable: LocalDate = timeMachine.getCurrentDate.minusDays(lateAppealDays())
 
-    //TODO: This will be replaced by UserAnswers value in future story when page is built
-    if (request.session.get(IncomeTaxSessionKeys.doYouWantToAppealBothPenalties).contains("yes")) {
-      firstPenaltyCommunicationDate.exists(_.isBefore(dateWhereLateAppealIsApplicable)) ||
-        secondPenaltyCommunicationDate.exists(_.isBefore(dateWhereLateAppealIsApplicable))
+    if(is2ndStageAppeal) {
+      //TODO: The logic to determine this for second stage appeal is dependent on an API change to 1811 to return
+      //      the date that the appeal was rejected. This will be implemented in a future story.
+      false
     } else {
-      communicationSent.isBefore(dateWhereLateAppealIsApplicable)
+      //TODO: This will be replaced by UserAnswers value in future story when page is built
+      if (request.session.get(IncomeTaxSessionKeys.doYouWantToAppealBothPenalties).contains("yes")) {
+        firstPenaltyCommunicationDate.exists(_.isBefore(dateWhereLateAppealIsApplicable)) ||
+          secondPenaltyCommunicationDate.exists(_.isBefore(dateWhereLateAppealIsApplicable))
+      } else {
+        communicationSent.isBefore(dateWhereLateAppealIsApplicable)
+      }
     }
   }
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/AppealStartView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/AppealStartView.scala.html
@@ -14,11 +14,9 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.CurrentUserRequestWithAnswers
 @import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.ViewUtils.titleBuilder
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.Layout
-@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.components
+@import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.views.html.{Layout, components}
 
 @this(
         layout: Layout,
@@ -28,7 +26,7 @@
         h2: components.H2,
         link: components.Link
 )
-@(isLate: Boolean, isAgent: Boolean)(implicit user: CurrentUserRequestWithAnswers[_], messages: Messages)
+@(isLate: Boolean, action: Call)(implicit user: CurrentUserRequestWithAnswers[_], messages: Messages)
 
 @layout(Some(titleBuilder(messages("service.indexPageTitle"))), backLinkEnabled = false) {
 
@@ -53,12 +51,6 @@
     @p("appeal.start.p5")
     @p("appeal.start.p6")
 
-    @defining(if(isAgent) {
-        controllers.routes.WhoPlannedToSubmitController.onPageLoad()
-    } else {
-        controllers.routes.ReasonableExcuseController.onPageLoad()
-    }){ nextPageUrl =>
-        @link(link = nextPageUrl.url, messageKey = "common.continue", classes = Some("govuk-button"))
-    }
+    @link(link = action.url, messageKey = "common.continue", classes = Some("govuk-button"))
 
 }

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ReasonableExcuseControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/ReasonableExcuseControllerISpec.scala
@@ -58,79 +58,103 @@ class ReasonableExcuseControllerISpec extends ComponentSpecHelper with ViewSpecH
   "GET /reason-for-missing-deadline" should {
     testNavBar("/reason-for-missing-deadline")()
 
-    "return an OK with a view pre-populated" when {
-      "the user is an authorised individual" in {
-        stubAuth(OK, successfulIndividualAuthResponse)
-        userAnswersRepo.upsertUserAnswer(
-          emptyUserAnswersWithLSP.setAnswer(ReasonableExcusePage, Bereavement)
-        ).futureValue
-        val result = get("/reason-for-missing-deadline")
-        result.status shouldBe OK
-        val document = Jsoup.parse(result.body)
-        document.select(s"#$Bereavement").hasAttr("checked") shouldBe true
-        document.select(s"#$Cessation").hasAttr("checked") shouldBe false
-      }
+    "when the appeal is a 2nd Stage Appeal" when {
+      "should save the reason as 'Other' and redirect" when {
+        "the user is an authorised individual" in {
+          stubAuth(OK, successfulIndividualAuthResponse)
+          userAnswersRepo.upsertUserAnswer(emptyUserAnswersWithLSP2ndStage).futureValue
 
-      "the user is an authorised agent" in {
-        stubAuth(OK, successfulAgentAuthResponse)
+          val result = get("/reason-for-missing-deadline")
+          result.status shouldBe SEE_OTHER
+          result.header("Location") shouldBe Some(routes.HonestyDeclarationController.onPageLoad().url)
+        }
 
-        val result = get("/reason-for-missing-deadline", isAgent = true)
+        "the user is an authorised Agent" in {
+          stubAuth(OK, successfulAgentAuthResponse)
+          userAnswersRepo.upsertUserAnswer(emptyUserAnswersWithLSP2ndStage).futureValue
 
-        result.status shouldBe OK
+          val result = get("/reason-for-missing-deadline", isAgent = true)
+          result.status shouldBe SEE_OTHER
+          result.header("Location") shouldBe Some(routes.HonestyDeclarationController.onPageLoad().url)
+        }
       }
     }
-    "the page has the correct elements" when {
-      "the user is an authorised individual" in {
-        stubAuth(OK, successfulIndividualAuthResponse)
-        val result = get("/reason-for-missing-deadline")
 
-        val document = Jsoup.parse(result.body)
+    "when the appeal is a 1st Stage Appeal" when {
+      "return an OK with a view pre-populated" when {
+        "the user is an authorised individual" in {
+          stubAuth(OK, successfulIndividualAuthResponse)
+          userAnswersRepo.upsertUserAnswer(
+            emptyUserAnswersWithLSP.setAnswer(ReasonableExcusePage, Bereavement)
+          ).futureValue
+          val result = get("/reason-for-missing-deadline")
+          result.status shouldBe OK
+          val document = Jsoup.parse(result.body)
+          document.select(s"#$Bereavement").hasAttr("checked") shouldBe true
+          document.select(s"#$Cessation").hasAttr("checked") shouldBe false
+        }
 
-        document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
-        document.title() shouldBe "What was the reason for missing the submission deadline? - Appeal a Self Assessment penalty - GOV.UK"
-        document.getElementById("captionSpan").text() shouldBe ReasonableExcuseMessages.English.lspCaption(
-          dateToString(lateSubmissionAppealData.startDate),
-          dateToString(lateSubmissionAppealData.endDate)
-        )
-        document.getH1Elements.text() shouldBe "What was the reason for missing the submission deadline?"
-        document.getHintText.get(0).text() shouldBe "If more than one reason applies, choose the one that had the most direct impact on your ability to meet the deadline."
-        document.getElementsByAttributeValue("for", s"$Bereavement").text() shouldBe "Bereavement (someone died)"
-        document.getElementsByAttributeValue("for", s"$Cessation").text() shouldBe "Cessation of income source"
-        document.getElementsByAttributeValue("for", s"$Crime").text() shouldBe "Crime"
-        document.getElementsByAttributeValue("for", s"$FireOrFlood").text() shouldBe "Fire or flood"
-        document.getElementsByAttributeValue("for", s"$Health").text() shouldBe "Serious or life-threatening ill health"
-        document.getElementsByAttributeValue("for", s"$TechnicalIssues").text() shouldBe "Software or technology issues"
-        document.getElementsByAttributeValue("for", s"$UnexpectedHospital").text() shouldBe "Unexpected hospital stay"
-        document.getElementsByAttributeValue("for", s"$Other").text() shouldBe "The reason does not fit into any of the other categories"
-        document.getHintText.get(1).text() shouldBe "You should only choose this if the reason is not covered by any of the other options."
-        document.getSubmitButton.text() shouldBe "Continue"
+        "the user is an authorised agent" in {
+          stubAuth(OK, successfulAgentAuthResponse)
+
+          val result = get("/reason-for-missing-deadline", isAgent = true)
+
+          result.status shouldBe OK
+        }
       }
+      "the page has the correct elements" when {
+        "the user is an authorised individual" in {
+          stubAuth(OK, successfulIndividualAuthResponse)
+          val result = get("/reason-for-missing-deadline")
 
-      "the user is an authorised agent" in {
-        stubAuth(OK, successfulAgentAuthResponse)
-        val result = get("/reason-for-missing-deadline", isAgent = true)
+          val document = Jsoup.parse(result.body)
 
-        val document = Jsoup.parse(result.body)
+          document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
+          document.title() shouldBe "What was the reason for missing the submission deadline? - Appeal a Self Assessment penalty - GOV.UK"
+          document.getElementById("captionSpan").text() shouldBe ReasonableExcuseMessages.English.lspCaption(
+            dateToString(lateSubmissionAppealData.startDate),
+            dateToString(lateSubmissionAppealData.endDate)
+          )
+          document.getH1Elements.text() shouldBe "What was the reason for missing the submission deadline?"
+          document.getHintText.get(0).text() shouldBe "If more than one reason applies, choose the one that had the most direct impact on your ability to meet the deadline."
+          document.getElementsByAttributeValue("for", s"$Bereavement").text() shouldBe "Bereavement (someone died)"
+          document.getElementsByAttributeValue("for", s"$Cessation").text() shouldBe "Cessation of income source"
+          document.getElementsByAttributeValue("for", s"$Crime").text() shouldBe "Crime"
+          document.getElementsByAttributeValue("for", s"$FireOrFlood").text() shouldBe "Fire or flood"
+          document.getElementsByAttributeValue("for", s"$Health").text() shouldBe "Serious or life-threatening ill health"
+          document.getElementsByAttributeValue("for", s"$TechnicalIssues").text() shouldBe "Software or technology issues"
+          document.getElementsByAttributeValue("for", s"$UnexpectedHospital").text() shouldBe "Unexpected hospital stay"
+          document.getElementsByAttributeValue("for", s"$Other").text() shouldBe "The reason does not fit into any of the other categories"
+          document.getHintText.get(1).text() shouldBe "You should only choose this if the reason is not covered by any of the other options."
+          document.getSubmitButton.text() shouldBe "Continue"
+        }
 
-        document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
-        document.title() shouldBe "What was the reason for missing the submission deadline? - Appeal a Self Assessment penalty - GOV.UK"
-        document.getElementById("captionSpan").text() shouldBe ReasonableExcuseMessages.English.lspCaption(
-          dateToString(lateSubmissionAppealData.startDate),
-          dateToString(lateSubmissionAppealData.endDate)
-        )
-        document.getH1Elements.text() shouldBe "What was the reason for missing the submission deadline?"
-        document.getHintText.get(0).text() shouldBe "If more than one reason applies, choose the one that had the most direct impact on your client’s ability to meet the deadline."
-        document.getElementsByAttributeValue("for", s"$Bereavement").text() shouldBe "Bereavement (someone died)"
-        document.getElementsByAttributeValue("for", s"$Cessation").text() shouldBe "Cessation of income source"
-        document.getElementsByAttributeValue("for", s"$Crime").text() shouldBe "Crime"
-        document.getElementsByAttributeValue("for", s"$FireOrFlood").text() shouldBe "Fire or flood"
-        document.getElementsByAttributeValue("for", s"$Health").text() shouldBe "Serious or life-threatening ill health"
-        document.getElementsByAttributeValue("for", s"$TechnicalIssues").text() shouldBe "Software or technology issues"
-        document.getElementsByAttributeValue("for", s"$UnexpectedHospital").text() shouldBe "Unexpected hospital stay"
-        document.getElementsByAttributeValue("for", s"$Other").text() shouldBe "The reason does not fit into any of the other categories"
-        document.getHintText.get(1).text() shouldBe "You should only choose this if the reason is not covered by any of the other options."
-        document.getSubmitButton.text() shouldBe "Continue"
+        "the user is an authorised agent" in {
+          stubAuth(OK, successfulAgentAuthResponse)
+          val result = get("/reason-for-missing-deadline", isAgent = true)
 
+          val document = Jsoup.parse(result.body)
+
+          document.getServiceName.text() shouldBe "Appeal a Self Assessment penalty"
+          document.title() shouldBe "What was the reason for missing the submission deadline? - Appeal a Self Assessment penalty - GOV.UK"
+          document.getElementById("captionSpan").text() shouldBe ReasonableExcuseMessages.English.lspCaption(
+            dateToString(lateSubmissionAppealData.startDate),
+            dateToString(lateSubmissionAppealData.endDate)
+          )
+          document.getH1Elements.text() shouldBe "What was the reason for missing the submission deadline?"
+          document.getHintText.get(0).text() shouldBe "If more than one reason applies, choose the one that had the most direct impact on your client’s ability to meet the deadline."
+          document.getElementsByAttributeValue("for", s"$Bereavement").text() shouldBe "Bereavement (someone died)"
+          document.getElementsByAttributeValue("for", s"$Cessation").text() shouldBe "Cessation of income source"
+          document.getElementsByAttributeValue("for", s"$Crime").text() shouldBe "Crime"
+          document.getElementsByAttributeValue("for", s"$FireOrFlood").text() shouldBe "Fire or flood"
+          document.getElementsByAttributeValue("for", s"$Health").text() shouldBe "Serious or life-threatening ill health"
+          document.getElementsByAttributeValue("for", s"$TechnicalIssues").text() shouldBe "Software or technology issues"
+          document.getElementsByAttributeValue("for", s"$UnexpectedHospital").text() shouldBe "Unexpected hospital stay"
+          document.getElementsByAttributeValue("for", s"$Other").text() shouldBe "The reason does not fit into any of the other categories"
+          document.getHintText.get(1).text() shouldBe "You should only choose this if the reason is not covered by any of the other options."
+          document.getSubmitButton.text() shouldBe "Continue"
+
+        }
       }
     }
   }

--- a/test-fixtures/fixtures/BaseFixtures.scala
+++ b/test-fixtures/fixtures/BaseFixtures.scala
@@ -90,6 +90,8 @@ trait BaseFixtures {
   val emptyUserAnswersWithLSP: UserAnswers = emptyUserAnswers.setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyDataLSP)
   val emptyUserAnswersWithLPP: UserAnswers = emptyUserAnswers.setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyDataLPP)
   val emptyUserAnswersWithMultipleLPPs: UserAnswers = emptyUserAnswers.setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyDataLPP.copy(multiplePenaltiesData = Some(multiplePenaltiesModel)))
+  val emptyUserAnswersWithLSP2ndStage: UserAnswers = emptyUserAnswers.setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyDataLSP.copy(is2ndStageAppeal = true))
+  val emptyUserAnswersWithLPP2ndStage: UserAnswers = emptyUserAnswers.setAnswerForKey[PenaltyData](IncomeTaxSessionKeys.penaltyData, penaltyDataLPP.copy(is2ndStageAppeal = true))
 
   val fakeRequestForCrimeJourney: CurrentUserRequestWithAnswers[AnyContent] = {
 

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswersSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswersSpec.scala
@@ -69,11 +69,11 @@ class CurrentUserRequestWithAnswersSpec extends AnyWordSpec with Matchers with G
       )
     }
 
-    val fakeRequestForAppealingSinglePenalty: LocalDate => CurrentUserRequestWithAnswers[AnyContent] = (date: LocalDate) => {
+    def fakeRequestForAppealingSinglePenalty(date: LocalDate, is2ndStageAppeal: Boolean = false): CurrentUserRequestWithAnswers[AnyContent] = {
 
       val penaltyData = PenaltyData(
         penaltyNumber = "123456789",
-        is2ndStageAppeal = false,
+        is2ndStageAppeal = is2ndStageAppeal,
         appealData = latePaymentAppealData.copy(dateCommunicationSent = date),
         multiplePenaltiesData = None
       )
@@ -105,6 +105,14 @@ class CurrentUserRequestWithAnswersSpec extends AnyWordSpec with Matchers with G
     }
 
     "return false" when {
+
+      "this is a 2nd Stage Appeal, so lateness does not matter as that was only relevant to 1st Stage Appeal" in new Setup(LocalDate.of(2022, 1, 1)) {
+        fakeRequestForAppealingSinglePenalty(
+          LocalDate.of(2021, 12, 1),
+          is2ndStageAppeal = true
+        ).isAppealLate() shouldBe false
+      }
+
       "communication date of penalty < 30 days ago" in new Setup(LocalDate.of(2022, 1, 1)) {
         fakeRequestForAppealingSinglePenalty(LocalDate.of(2021, 12, 31)).isAppealLate() shouldBe false
       }

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealServiceSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/AppealServiceSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
@@ -39,7 +39,7 @@ import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.{TimeMachine, UUIDGenerator}
 import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
 
-import java.time.LocalDate
+import java.time.{LocalDate, LocalDateTime}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -63,6 +63,7 @@ class AppealServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
       new AppealService(mockPenaltiesConnector, mockUpscanService, mockUUIDGenerator)(mockTimeMachine, appConfig)
 
     when(mockTimeMachine.getCurrentDate).thenReturn(LocalDate.of(2020, 2, 1))
+    when(mockTimeMachine.getCurrentDateTime).thenReturn(LocalDateTime.of(2020, 2, 1, 12, 15, 45))
     when(mockUUIDGenerator.generateUUID).thenReturn("uuid-1", "uuid-2")
   }
 

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/helpers/PrintAppealHelperSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/helpers/PrintAppealHelperSpec.scala
@@ -23,14 +23,12 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.twirl.api.Html
-import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{Cy, En}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.ReasonableExcuse.Health
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.{AgentClientEnum, CurrentUserRequestWithAnswers}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.pages._
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.DateFormatter.dateToString
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.TimeMachine
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.viewmodels.checkAnswers._
 
 import java.time.LocalDate
 


### PR DESCRIPTION
**Note:**
- This does not update content, that will be done separately
- There is a big assumption on this PR that 'Other' will be sent as the `reasonableExcuse` 
-  `eventHappenedDate` has been hard coded to today's date when it's a 2nd Stage Appeal, because the Penalties BE will need an API change to make it optional (as the User Journey does not ask for it)
- TODOs have been left in to ensure this gets revisited in future