### PR TITLE
[MIPR-1650] Add validation for filename on callback from upscan and render error

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/internal/UpscanCallbackController.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/internal/UpscanCallbackController.scala
@@ -18,13 +18,16 @@ package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.internal
 
 import play.api.libs.json.JsValue
 import play.api.mvc.{Action, MessagesControllerComponents}
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.UploadJourney
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.FailureReasonEnum.INVALID_FILENAME
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.{FailureDetails, UploadJourney}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.UploadStatusEnum.FAILED
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.UpscanService
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils.Logger.logger
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.matching.Regex
 
 class UpscanCallbackController @Inject()(service: UpscanService,
                                          override val controllerComponents: MessagesControllerComponents)
@@ -34,7 +37,8 @@ class UpscanCallbackController @Inject()(service: UpscanService,
     withJsonBody[UploadJourney] { callbackModel =>
       service.getFile(journeyId, callbackModel.reference).flatMap {
         case Some(file) =>
-          service.upsertFileUpload(journeyId, callbackModel.copy(uploadFields = file.uploadFields)).map { _ =>
+          val validatedCallbackModel = validateFilename(callbackModel.copy(uploadFields = file.uploadFields))
+          service.upsertFileUpload(journeyId, validatedCallbackModel).map { _ =>
             NoContent
           }
         case _ =>
@@ -43,4 +47,23 @@ class UpscanCallbackController @Inject()(service: UpscanService,
       }
     }
   }
+
+  private val validFilenameRegex: Regex = "^[a-zA-Z0-9-_.]+$".r
+
+  private[internal] def validateFilename(callbackModel: UploadJourney): UploadJourney =
+    callbackModel.uploadDetails.fold(callbackModel) { uploadDetails =>
+      validFilenameRegex.findFirstMatchIn(uploadDetails.fileName) match {
+        case Some(_) => callbackModel
+        case _ =>
+          logger.warn(s"[UpscanCallbackController][validateFilename] Callback from Upscan received with invalid filename")
+          logger.debug(s"[UpscanCallbackController][validateFilename] Invalid Filename: ${uploadDetails.fileName}")
+          callbackModel.copy(
+            fileStatus = FAILED,
+            failureDetails = Some(FailureDetails(
+              INVALID_FILENAME,
+              s"Filename contains invalid characters, filename='${uploadDetails.fileName}'"
+            ))
+          )
+      }
+    }
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/upscan/UploadDocumentForm.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/upscan/UploadDocumentForm.scala
@@ -31,6 +31,7 @@ object UploadDocumentForm {
     case "InvalidArgument" => messages("uploadEvidence.error.noFileSpecified")
     case "QUARANTINE" => messages(s"uploadEvidence.error.QUARANTINE")
     case "REJECTED" => messages(s"uploadEvidence.error.REJECTED")
+    case "INVALID_FILENAME" => messages(s"uploadEvidence.error.INVALID_FILENAME")
     case _ => messages("uploadEvidence.error.unableToUpload")
   }
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/FailureReasonEnum.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/FailureReasonEnum.scala
@@ -24,6 +24,7 @@ object FailureReasonEnum extends Enumeration {
   val QUARANTINE: FailureReasonEnum.Value = Value
   val REJECTED: FailureReasonEnum.Value = Value
   val UNKNOWN: FailureReasonEnum.Value = Value
+  val INVALID_FILENAME: FailureReasonEnum.Value = Value
 
   implicit def format: Format[FailureReasonEnum.Value] = new Format[FailureReasonEnum.Value] {
     override def writes(o: FailureReasonEnum.Value): JsValue = JsString(o.toString.toUpperCase)

--- a/conf/messages
+++ b/conf/messages
@@ -434,6 +434,8 @@ uploadEvidence.error.unableToUpload = The selected file could not be uploaded. C
 # ----------------------------------------------------------
 uploadEvidence.error.QUARANTINE = The selected file contains a virus. Choose another file.
 uploadEvidence.error.REJECTED = The selected file must be a JPG, PNG, TIFF, PDF, TXT, MSG, Word, Excel, Powerpoint or Open Document Format (ODF). Choose another file.
+#TODO: Update error message below with wording from Phil when ready
+uploadEvidence.error.INVALID_FILENAME = The selected file name is invalid (placeholder!!!)
 
 # NonJs Upscan Check Answers (Add Another file) page
 # ----------------------------------------------------------

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -262,6 +262,8 @@ uploadEvidence.error.unableToUpload = Nid oedd modd uwchlwytho’r ffeil dan syl
 # ----------------------------------------------------------
 uploadEvidence.error.QUARANTINE = Mae feirws yn y ffeil dan sylw. Dewiswch ffeil arall.
 uploadEvidence.error.REJECTED = Mae’n rhaid i’r ffeil dan sylw fod yn JPG, PNG, TIFF, PDF, TXT, MSG, Word, Excel, Powerpoint neu Fformat Dogfen Agored (ODF)
+#TODO: Update error message below with wording from Phil when ready
+uploadEvidence.error.INVALID_FILENAME = The selected file name is invalid (placeholder!!!) (Welsh)
 
 # NonJs Upscan Check Answers (Add Another file) page
 # ----------------------------------------------------------

--- a/test-fixtures/fixtures/messages/UpscanErrorMessages.scala
+++ b/test-fixtures/fixtures/messages/UpscanErrorMessages.scala
@@ -16,7 +16,7 @@
 
 package fixtures.messages
 
-object SynchronousUpscanErrorMessages {
+object UpscanErrorMessages {
 
   sealed trait Messages { _: i18n =>
     val errorFileTooSmall: String = "The selected file is empty. Choose another file."
@@ -25,6 +25,7 @@ object SynchronousUpscanErrorMessages {
     val errorUploadFailed: String = "The selected file could not be uploaded. Choose another file."
     val errorQuarantine: String = "The selected file contains a virus. Choose another file."
     val errorRejected: String = "The selected file must be a JPG, PNG, TIFF, PDF, TXT, MSG, Word, Excel, Powerpoint or Open Document Format (ODF). Choose another file."
+    val errorFilename: String = "The selected file name is invalid (placeholder!!!)"
   }
 
   object English extends Messages with En
@@ -36,5 +37,6 @@ object SynchronousUpscanErrorMessages {
     override val errorUploadFailed: String = "Nid oedd modd uwchlwytho’r ffeil dan sylw. Dewiswch ffeil arall."
     override val errorQuarantine: String = "Mae feirws yn y ffeil dan sylw. Dewiswch ffeil arall."
     override val errorRejected: String = "Mae’n rhaid i’r ffeil dan sylw fod yn JPG, PNG, TIFF, PDF, TXT, MSG, Word, Excel, Powerpoint neu Fformat Dogfen Agored (ODF)"
+    override val errorFilename: String = "The selected file name is invalid (placeholder!!!) (Welsh)"
   }
 }

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/internal/UpscanCallbackControllerSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/internal/UpscanCallbackControllerSpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.internal
+
+import fixtures.FileUploadFixtures
+import org.scalatest.matchers.should
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.FailureReasonEnum.INVALID_FILENAME
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.UploadStatusEnum.FAILED
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.{FailureDetails, UploadJourney}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.services.mocks.MockUpscanService
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+
+import scala.concurrent.ExecutionContext
+
+class UpscanCallbackControllerSpec extends AnyWordSpec with should.Matchers with GuiceOneAppPerSuite
+  with LogCapturing with MockUpscanService with FileUploadFixtures {
+
+  implicit lazy val ec: ExecutionContext = ExecutionContext.global
+  lazy val controller: UpscanCallbackController = new UpscanCallbackController(mockUpscanService, stubMessagesControllerComponents())
+
+  implicit class FileDecorator(file: UploadJourney) {
+    def withFilename(filename: String): UploadJourney =
+      file.copy(uploadDetails = file.uploadDetails.map(_.copy(fileName = filename)))
+  }
+
+  "UpscanCallbackController" when {
+
+    "calling .validateFilename()" when {
+
+      Seq(
+        "file1.txt",
+        "file_1.txt",
+        "file-1.txt",
+        "File1.txt",
+        "F_I_L_E_1.txt",
+        "file.name.one.txt"
+      ).foreach { validFilenameExample =>
+
+        s"the filename is valid (filename=$validFilenameExample)" should {
+
+          "return the callback model unchanged" in {
+            val file = callbackModel.withFilename(validFilenameExample)
+            controller.validateFilename(file) shouldBe file
+          }
+        }
+      }
+
+      Seq(
+        "file&1.txt",
+        "file 1.txt",
+        "file 2.txt", //&nbsp;
+        "£file.txt",
+        "@file.txt"
+      ).foreach { invalidFilenameExample =>
+
+        s"the filename is invalid (filename=$invalidFilenameExample)" should {
+
+          "return the callback model unchanged" in {
+            val file = callbackModel.withFilename(invalidFilenameExample)
+            controller.validateFilename(file) shouldBe file.copy(
+              fileStatus = FAILED,
+              failureDetails = Some(FailureDetails(
+                failureReason = INVALID_FILENAME,
+                message = s"Filename contains invalid characters, filename='$invalidFilenameExample'"
+              ))
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/upscan/UploadDocumentFormSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/upscan/UploadDocumentFormSpec.scala
@@ -16,20 +16,20 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan
 
-import fixtures.messages.SynchronousUpscanErrorMessages
+import fixtures.messages.UpscanErrorMessages
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Lang, Messages, MessagesApi}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
-import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.FailureReasonEnum.{QUARANTINE, REJECTED, UNKNOWN}
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.models.upscan.FailureReasonEnum.{INVALID_FILENAME, QUARANTINE, REJECTED, UNKNOWN}
 
 class UploadDocumentFormSpec extends AnyWordSpec with should.Matchers with GuiceOneAppPerSuite {
 
   implicit lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
   lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
 
-  Seq(SynchronousUpscanErrorMessages.English, SynchronousUpscanErrorMessages.Welsh).foreach { messagesForLanguage =>
+  Seq(UpscanErrorMessages.English, UpscanErrorMessages.Welsh).foreach { messagesForLanguage =>
 
     s"rendering the form in '${messagesForLanguage.lang.name}'" when {
 
@@ -57,6 +57,10 @@ class UploadDocumentFormSpec extends AnyWordSpec with should.Matchers with Guice
 
       s"have the correct error message for the $UNKNOWN code" in {
         UploadDocumentForm.errorMessages(UNKNOWN.toString) shouldBe messagesForLanguage.errorUploadFailed
+      }
+
+      s"have the correct error message for the $INVALID_FILENAME code" in {
+        UploadDocumentForm.errorMessages(INVALID_FILENAME.toString) shouldBe messagesForLanguage.errorFilename
       }
 
       "have the correct error message for any other code" in {


### PR DESCRIPTION
**Note:**
- the error message for this is currently a placeholder and will need to be updated on a future ticket