### PR TITLE
[MIPR-1651] Update upscan filesize limit to 10MB

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
@@ -89,6 +89,7 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
 
   lazy val upscanMinFileSize: Int = config.get[Int]("upscan.minFileSize")
   lazy val upscanMaxFileSize: Int = config.get[Int]("upscan.maxFileSize")
+  lazy val upscanMaxFileSizeMB: Int = upscanMaxFileSize / 1024 / 1024
   lazy val upscanMaxNumberOfFiles: Int = config.get[Int]("upscan.maxNumberOfFiles")
   lazy val upscanAcceptedMimeTypes: String = config.get[String]("upscan.acceptedMimeTypes")
   lazy val upscanCheckInterval: FiniteDuration = config.get[FiniteDuration]("upscan.checkInterval")

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/upscan/UploadDocumentForm.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/upscan/UploadDocumentForm.scala
@@ -19,15 +19,16 @@ package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.forms.upscan
 import play.api.data.Form
 import play.api.data.Forms.text
 import play.api.i18n.Messages
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 
 object UploadDocumentForm {
 
   val key = "file"
   val form: Form[String] = Form[String](key -> text)
 
-  def errorMessages(code: String)(implicit messages: Messages): String = code match {
+  def errorMessages(code: String)(implicit messages: Messages, appConfig: AppConfig): String = code match {
     case "EntityTooSmall" => messages("uploadEvidence.error.fileTooSmall")
-    case "EntityTooLarge" => messages("uploadEvidence.error.fileTooLarge")
+    case "EntityTooLarge" => messages("uploadEvidence.error.fileTooLarge", appConfig.upscanMaxFileSizeMB)
     case "InvalidArgument" => messages("uploadEvidence.error.noFileSpecified")
     case "QUARANTINE" => messages(s"uploadEvidence.error.QUARANTINE")
     case "REJECTED" => messages(s"uploadEvidence.error.REJECTED")

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswers.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/CurrentUserRequestWithAnswers.scala
@@ -53,7 +53,6 @@ case class CurrentUserRequestWithAnswers[A](mtdItId: String,
   val secondPenaltyNumber: Option[String] = penaltyData.multiplePenaltiesData.map(_.secondPenaltyChargeReference)
   val firstPenaltyCommunicationDate: Option[LocalDate] = penaltyData.multiplePenaltiesData.map(_.firstPenaltyCommunicationDate)
   val secondPenaltyCommunicationDate: Option[LocalDate] = penaltyData.multiplePenaltiesData.map(_.secondPenaltyCommunicationDate)
-  val isAppealingMultipleLPPs: Boolean = userAnswers.getAnswer(JointAppealPage).contains(true)
 
   def getMandatoryAnswer[T](page: Page[T])(implicit reads: Reads[T]): T =
     userAnswers.getAnswer(page) match {

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsFileUploadView.scala.html
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsFileUploadView.scala.html
@@ -63,7 +63,7 @@
     <p class="govuk-body">@messages("uploadEvidence.nonJs.p1")</p>
     <p class="govuk-body">@messages("uploadEvidence.nonJs.p2")</p>
     <p class="govuk-body">@messages("uploadEvidence.nonJs.p3", appConfig.upscanMaxNumberOfFiles)</p>
-    <p class="govuk-body">@messages("uploadEvidence.nonJs.p4", appConfig.upscanMaxFileSize)</p>
+    <p class="govuk-body">@messages("uploadEvidence.nonJs.p4", appConfig.upscanMaxFileSizeMB)</p>
 
     @details("uploadEvidence.typesOfFile.heading", supportedFileTypes)
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -153,7 +153,7 @@ constants {
 
 upscan {
   minFileSize = 1
-  maxFileSize = 6291456
+  maxFileSize = 10485760
   maxNumberOfFiles = 5
   acceptedMimeTypes = "image/jpeg,image/png,image/tiff,application/pdf,text/plain,application/vnd.ms-outlook,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.text,application/vnd.oasis.opendocument.spreadsheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.oasis.opendocument.presentation"
   checkInterval = 500millis

--- a/conf/messages
+++ b/conf/messages
@@ -414,7 +414,7 @@ uploadEvidence.nonJs.headingAndTitle = Evidence to support this appeal
 uploadEvidence.nonJs.p1 = Use this page to upload any evidence to help us review the penalty.
 uploadEvidence.nonJs.p2 = Evidence might include any documents or letters that show why the submission deadline was missed.
 uploadEvidence.nonJs.p3 = You can upload up to {0} files.
-uploadEvidence.nonJs.p4 = Each file must be smaller than 6MB.
+uploadEvidence.nonJs.p4 = Each file must be smaller than {0}MB.
 uploadEvidence.nonJs.label = Select a file
 
 # NonJS File Upload Page
@@ -430,7 +430,7 @@ uploadEvidence.typesOfFile.li.5 = Open Document Format (ODF)
 # Synchronous Upscan Error
 # ----------------------------------------------------------
 uploadEvidence.error.fileTooSmall = The selected file is empty. Choose another file.
-uploadEvidence.error.fileTooLarge = The selected file must be smaller than 6MB. Choose another file.
+uploadEvidence.error.fileTooLarge = The selected file must be smaller than {0}MB. Choose another file.
 uploadEvidence.error.noFileSpecified = Select a file.
 uploadEvidence.error.unableToUpload = The selected file could not be uploaded. Choose another file.
 

--- a/conf/messages
+++ b/conf/messages
@@ -438,8 +438,7 @@ uploadEvidence.error.unableToUpload = The selected file could not be uploaded. C
 # ----------------------------------------------------------
 uploadEvidence.error.QUARANTINE = The selected file contains a virus. Choose another file.
 uploadEvidence.error.REJECTED = The selected file must be a JPG, PNG, TIFF, PDF, TXT, MSG, Word, Excel, Powerpoint or Open Document Format (ODF). Choose another file.
-#TODO: Update error message below with wording from Phil when ready
-uploadEvidence.error.INVALID_FILENAME = The selected file name is invalid (placeholder!!!)
+uploadEvidence.error.INVALID_FILENAME = Filenames can only contain upper and lower case letters, digits from 0-9, hyphens, underscores and full stops.
 
 # NonJs Upscan Check Answers (Add Another file) page
 # ----------------------------------------------------------

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -245,7 +245,7 @@ uploadEvidence.nonJs.headingAndTitle = Evidence to support this appeal (Welsh)
 uploadEvidence.nonJs.p1 = Use this page to upload any evidence to help us review the penalty. (Welsh)
 uploadEvidence.nonJs.p2 = Evidence might include any documents or letters that show why the submission deadline was missed. (Welsh)
 uploadEvidence.nonJs.p3 = You can upload up to {0} files. (Welsh)
-uploadEvidence.nonJs.p4 = Each file must be smaller than 6MB. (Welsh)
+uploadEvidence.nonJs.p4 = Each file must be smaller than {0}MB. (Welsh)
 uploadEvidence.nonJs.label = Select a file (Welsh)
 
 # NonJS File Upload Page
@@ -261,7 +261,7 @@ uploadEvidence.typesOfFile.li.5 = Open Document Format (ODF) (Welsh)
 # Synchronous Upscan Error
 # ----------------------------------------------------------
 uploadEvidence.error.fileTooSmall = Mae’r ffeil dan sylw yn wag. Dewiswch ffeil arall.
-uploadEvidence.error.fileTooLarge = Mae’n rhaid i’r ffeil dan sylw fod yn llai na 6 MB. Dewiswch ffeil arall.
+uploadEvidence.error.fileTooLarge = Mae’n rhaid i’r ffeil dan sylw fod yn llai na {0}MB. Dewiswch ffeil arall.
 uploadEvidence.error.noFileSpecified = Dewiswch ffeil.
 uploadEvidence.error.unableToUpload = Nid oedd modd uwchlwytho’r ffeil dan sylw. Dewiswch ffeil arall.
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -269,8 +269,7 @@ uploadEvidence.error.unableToUpload = Nid oedd modd uwchlwytho’r ffeil dan syl
 # ----------------------------------------------------------
 uploadEvidence.error.QUARANTINE = Mae feirws yn y ffeil dan sylw. Dewiswch ffeil arall.
 uploadEvidence.error.REJECTED = Mae’n rhaid i’r ffeil dan sylw fod yn JPG, PNG, TIFF, PDF, TXT, MSG, Word, Excel, Powerpoint neu Fformat Dogfen Agored (ODF)
-#TODO: Update error message below with wording from Phil when ready
-uploadEvidence.error.INVALID_FILENAME = The selected file name is invalid (placeholder!!!) (Welsh)
+uploadEvidence.error.INVALID_FILENAME = Filenames can only contain upper and lower case letters, digits from 0-9, hyphens, underscores and full stops. (Welsh)
 
 # NonJs Upscan Check Answers (Add Another file) page
 # ----------------------------------------------------------

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,8 +7,8 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"        %% "bootstrap-frontend-play-30" % bootstrapVersion,
-    "uk.gov.hmrc"        %% "play-frontend-hmrc-play-30" % "11.11.0",
-    "uk.gov.hmrc.mongo"  %% "hmrc-mongo-play-30"         % "1.6.0",
+    "uk.gov.hmrc"        %% "play-frontend-hmrc-play-30" % "11.12.0",
+    "uk.gov.hmrc.mongo"  %% "hmrc-mongo-play-30"         % "1.9.0",
     "uk.gov.hmrc"        %% "crypto-json-play-30"        % "7.6.0"
   )
 

--- a/test-fixtures/fixtures/messages/UpscanErrorMessages.scala
+++ b/test-fixtures/fixtures/messages/UpscanErrorMessages.scala
@@ -20,7 +20,7 @@ object UpscanErrorMessages {
 
   sealed trait Messages { _: i18n =>
     val errorFileTooSmall: String = "The selected file is empty. Choose another file."
-    val errorFileTooLarge: String = "The selected file must be smaller than 6MB. Choose another file."
+    val errorFileTooLarge: Int => String = max => s"The selected file must be smaller than ${max}MB. Choose another file."
     val errorNoFileSelected: String = "Select a file."
     val errorUploadFailed: String = "The selected file could not be uploaded. Choose another file."
     val errorQuarantine: String = "The selected file contains a virus. Choose another file."
@@ -32,7 +32,7 @@ object UpscanErrorMessages {
 
   object Welsh extends Messages with Cy {
     override val errorFileTooSmall: String = "Mae’r ffeil dan sylw yn wag. Dewiswch ffeil arall."
-    override val errorFileTooLarge: String = "Mae’n rhaid i’r ffeil dan sylw fod yn llai na 6 MB. Dewiswch ffeil arall."
+    override val errorFileTooLarge: Int => String = max => s"Mae’n rhaid i’r ffeil dan sylw fod yn llai na ${max}MB. Dewiswch ffeil arall."
     override val errorNoFileSelected: String = "Dewiswch ffeil."
     override val errorUploadFailed: String = "Nid oedd modd uwchlwytho’r ffeil dan sylw. Dewiswch ffeil arall."
     override val errorQuarantine: String = "Mae feirws yn y ffeil dan sylw. Dewiswch ffeil arall."

--- a/test-fixtures/fixtures/messages/UpscanErrorMessages.scala
+++ b/test-fixtures/fixtures/messages/UpscanErrorMessages.scala
@@ -25,7 +25,7 @@ object UpscanErrorMessages {
     val errorUploadFailed: String = "The selected file could not be uploaded. Choose another file."
     val errorQuarantine: String = "The selected file contains a virus. Choose another file."
     val errorRejected: String = "The selected file must be a JPG, PNG, TIFF, PDF, TXT, MSG, Word, Excel, Powerpoint or Open Document Format (ODF). Choose another file."
-    val errorFilename: String = "The selected file name is invalid (placeholder!!!)"
+    val errorFilename: String = "Filenames can only contain upper and lower case letters, digits from 0-9, hyphens, underscores and full stops."
   }
 
   object English extends Messages with En
@@ -37,6 +37,6 @@ object UpscanErrorMessages {
     override val errorUploadFailed: String = "Nid oedd modd uwchlwytho’r ffeil dan sylw. Dewiswch ffeil arall."
     override val errorQuarantine: String = "Mae feirws yn y ffeil dan sylw. Dewiswch ffeil arall."
     override val errorRejected: String = "Mae’n rhaid i’r ffeil dan sylw fod yn JPG, PNG, TIFF, PDF, TXT, MSG, Word, Excel, Powerpoint neu Fformat Dogfen Agored (ODF)"
-    override val errorFilename: String = "The selected file name is invalid (placeholder!!!) (Welsh)"
+    override val errorFilename: String = "Filenames can only contain upper and lower case letters, digits from 0-9, hyphens, underscores and full stops. (Welsh)"
   }
 }

--- a/test-fixtures/fixtures/messages/upscan/NonJsFileUploadMessages.scala
+++ b/test-fixtures/fixtures/messages/upscan/NonJsFileUploadMessages.scala
@@ -25,7 +25,7 @@ object NonJsFileUploadMessages {
     val p1 = "Use this page to upload any evidence to help us review the penalty."
     val p2 = "Evidence might include any documents or letters that show why the submission deadline was missed."
     val p3: Int => String = n => s"You can upload up to $n files."
-    val p4 = "Each file must be smaller than 6MB."
+    val p4: Int => String = n => s"Each file must be smaller than ${n}MB."
     val label = "Select a file"
   }
 
@@ -36,7 +36,7 @@ object NonJsFileUploadMessages {
     override val p1 = "Use this page to upload any evidence to help us review the penalty. (Welsh)"
     override val p2 = "Evidence might include any documents or letters that show why the submission deadline was missed. (Welsh)"
     override val p3: Int => String = n => s"You can upload up to $n files. (Welsh)"
-    override val p4 = "Each file must be smaller than 6MB. (Welsh)"
+    override val p4: Int => String = n => s"Each file must be smaller than ${n}MB. (Welsh)"
     override val label = "Select a file (Welsh)"
   }
 }

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/upscan/UploadDocumentFormSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/forms/upscan/UploadDocumentFormSpec.scala
@@ -40,7 +40,7 @@ class UploadDocumentFormSpec extends AnyWordSpec with should.Matchers with Guice
       }
 
       "have the correct error message for the EntityTooLarge code" in {
-        UploadDocumentForm.errorMessages("EntityTooLarge") shouldBe messagesForLanguage.errorFileTooLarge
+        UploadDocumentForm.errorMessages("EntityTooLarge") shouldBe messagesForLanguage.errorFileTooLarge(appConfig.upscanMaxFileSizeMB)
       }
 
       "have the correct error message for the InvalidArgument code" in {

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UpscanInitiateRequestSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/models/upscan/UpscanInitiateRequestSpec.scala
@@ -38,7 +38,7 @@ class UpscanInitiateRequestSpec extends AnyWordSpec with Matchers with GuiceOneA
         successRedirect = Some("http://localhost:9188" + upscanRoutes.UpscanInitiateController.onSubmitSuccessRedirect("").url.replace("?key=", "")),
         errorRedirect   = Some("http://localhost:9188" + upscanRoutes.UpscanInitiateController.onPageLoad().url),
         minimumFileSize = Some(1),
-        maximumFileSize = Some(6291456)
+        maximumFileSize = Some(10485760)
       )
 
       actualModel shouldBe expectedModel

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsFileUploadViewSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/views/upscan/NonJsFileUploadViewSpec.scala
@@ -54,7 +54,7 @@ class NonJsFileUploadViewSpec extends ViewBehaviours with GuiceOneAppPerSuite wi
         Selectors.p(1) -> messagesForLanguage.p1,
         Selectors.p(2) -> messagesForLanguage.p2,
         Selectors.p(3) -> messagesForLanguage.p3(appConfig.upscanMaxNumberOfFiles),
-        Selectors.p(4) -> messagesForLanguage.p4,
+        Selectors.p(4) -> messagesForLanguage.p4(appConfig.upscanMaxFileSizeMB),
         Selectors.detailsSummary -> fileTypeMessages.summaryHeading,
         concat(Selectors.details, Selectors.p(1)) -> fileTypeMessages.p1,
         concat(Selectors.details, Selectors.bullet(1)) -> fileTypeMessages.bullet1,


### PR DESCRIPTION
**Notes**:
- This PR updates the view and error messages to be derived from config, so in future the number of bytes can be updated and the MB on the view will update automatically
- The below PR needs to be reviewed and merged before this one:
  - #60 