### PR TITLE
MIPR-1684: TimeMachine Class

### DIFF
--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
@@ -103,7 +103,7 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
 
   lazy val timeMachineDate: String =
     config.get[String]("timemachine.date")
-  private val timeMachineDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+  private val timeMachineDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
 
   def optCurrentDate: Option[LocalDate]  = if (timeMachineEnabled && !timeMachineDate.equalsIgnoreCase("now")){
     Try(LocalDate.parse(timeMachineDate, timeMachineDateFormatter)).toOption

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
@@ -19,8 +19,11 @@ import play.api.Configuration
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.featureswitch.core.config.{FeatureSwitching, StubIncomeTaxSessionData, UseStubForBackend}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.util.Try
 
 @Singleton
 class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesConfig) extends FeatureSwitching {
@@ -94,4 +97,15 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
   lazy val upscanTimeout: FiniteDuration = config.get[FiniteDuration]("upscan.timeout")
 
   lazy val enterClientUTRVandCUrl: String = config.get[String]("income-tax-view-change.enterClientUTR.url")
+
+  lazy val timeMachineEnabled: Boolean =
+    config.get[Boolean]("timemachine.enabled")
+
+  lazy val timeMachineDate: String =
+    config.get[String]("timemachine.date")
+  private val timeMachineDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+
+  def optCurrentDate: Option[LocalDate]  = if (timeMachineEnabled && !timeMachineDate.equalsIgnoreCase("now")){
+    Try(LocalDate.parse(timeMachineDate, timeMachineDateFormatter)).toOption
+  } else None
 }

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/config/AppConfig.scala
@@ -103,7 +103,7 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
 
   lazy val timeMachineDate: String =
     config.get[String]("timemachine.date")
-  private val timeMachineDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
+  private val timeMachineDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yy")
 
   def optCurrentDate: Option[LocalDate]  = if (timeMachineEnabled && !timeMachineDate.equalsIgnoreCase("now")){
     Try(LocalDate.parse(timeMachineDate, timeMachineDateFormatter)).toOption

--- a/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/TimeMachine.scala
+++ b/app/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/TimeMachine.scala
@@ -16,11 +16,13 @@
 
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils
 
+import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
+
 import java.time.{LocalDate, LocalDateTime}
 import javax.inject.{Inject, Singleton}
 
 @Singleton
-class TimeMachine @Inject() {
+class TimeMachine @Inject()(appConfig: AppConfig) {
   def getCurrentDateTime: LocalDateTime = LocalDateTime.now()
-  def getCurrentDate: LocalDate = getCurrentDateTime.toLocalDate
+  def getCurrentDate: LocalDate = appConfig.optCurrentDate.getOrElse(LocalDate.now())
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -160,3 +160,8 @@ upscan {
   checkInterval = 500millis
   timeout = 2seconds
 }
+
+timemachine{
+    enabled = true
+    date = "now"
+}

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/InitialisationControllerISpec.scala
@@ -40,7 +40,7 @@ class InitialisationControllerISpec extends ControllerISpecHelper
 
   val testDateTime: LocalDateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)
 
-  lazy val timeMachine: TimeMachine = new TimeMachine {
+  lazy val timeMachine: TimeMachine = new TimeMachine(appConfig) {
     override def getCurrentDateTime: LocalDateTime = testDateTime
   }
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanCheckAnswersControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanCheckAnswersControllerISpec.scala
@@ -23,6 +23,7 @@ import org.jsoup.Jsoup
 import org.mongodb.scala.Document
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.http.Status.{OK, SEE_OTHER}
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.{Application, inject}
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.config.AppConfig
 import uk.gov.hmrc.incometaxpenaltiesappealsfrontend.controllers.{ControllerISpecHelper, routes => appealsRoutes}
@@ -40,15 +41,19 @@ import java.time.temporal.ChronoUnit
 class UpscanCheckAnswersControllerISpec extends ControllerISpecHelper
   with FileUploadFixtures {
 
-  override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  private lazy val configApp: Application =
+    new GuiceApplicationBuilder().build()
 
-  lazy val timeMachine: TimeMachine = new TimeMachine {
+  override lazy val appConfig: AppConfig = configApp.injector.instanceOf[AppConfig]
+
+  lazy val timeMachine: TimeMachine = new TimeMachine(appConfig) {
     override def getCurrentDateTime: LocalDateTime = testDateTime
   }
 
   override lazy val app: Application = appWithOverrides(
     inject.bind[TimeMachine].toInstance(timeMachine)
   )
+
 
   lazy val userAnswersRepo: UserAnswersRepository = app.injector.instanceOf[UserAnswersRepository]
   lazy val fileUploadRepo: FileUploadJourneyRepository = app.injector.instanceOf[FileUploadJourneyRepository]

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanInitiateControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanInitiateControllerISpec.scala
@@ -40,7 +40,7 @@ class UpscanInitiateControllerISpec extends ControllerISpecHelper
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
 
-  lazy val timeMachine: TimeMachine = new TimeMachine {
+  lazy val timeMachine: TimeMachine = new TimeMachine(appConfig) {
     override def getCurrentDateTime: LocalDateTime = testDateTime
   }
 

--- a/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanRemoveFileControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/controllers/upscan/UpscanRemoveFileControllerISpec.scala
@@ -38,7 +38,7 @@ class UpscanRemoveFileControllerISpec extends ControllerISpecHelper
 
   override val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
 
-  lazy val timeMachine: TimeMachine = new TimeMachine {
+  lazy val timeMachine: TimeMachine = new TimeMachine(appConfig) {
     override def getCurrentDateTime: LocalDateTime = testDateTime
   }
 

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/UpscanServiceSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/services/UpscanServiceSpec.scala
@@ -47,7 +47,7 @@ class UpscanServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with
 
   lazy val testDateTime: LocalDateTime = LocalDateTime.now()
 
-  lazy val timeMachine: TimeMachine = new TimeMachine {
+  lazy val timeMachine: TimeMachine = new TimeMachine(appConfig) {
     override def getCurrentDateTime: LocalDateTime = testDateTime
   }
 

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/TimeMachineSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/TimeMachineSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils
 
 import org.scalatest.matchers.should.Matchers
@@ -9,7 +25,7 @@ import java.time.format.DateTimeFormatter
 
 class TimeMachineSpec extends AnyWordSpec with Matchers{
 
-  private val dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
+  private val dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yy")
 
 
   "TimeMachine -getCurrentDate" should {
@@ -17,11 +33,11 @@ class TimeMachineSpec extends AnyWordSpec with Matchers{
     "Return the configured date specified" in {
       val app = new GuiceApplicationBuilder().configure(
         "timemachine.enabled" -> true,
-        "timemachine.date" -> "01-01-2021"
+        "timemachine.date" -> "01-01-21"
       ).build()
 
       val timeMachine = app.injector.instanceOf[TimeMachine]
-      timeMachine.getCurrentDate shouldEqual LocalDate.parse("01-01-2021", dateFormatter)
+      timeMachine.getCurrentDate shouldEqual LocalDate.parse("01-01-21", dateFormatter)
     }
   }
 

--- a/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/TimeMachineSpec.scala
+++ b/test/uk/gov/hmrc/incometaxpenaltiesappealsfrontend/utils/TimeMachineSpec.scala
@@ -1,0 +1,59 @@
+package uk.gov.hmrc.incometaxpenaltiesappealsfrontend.utils
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.inject.guice.GuiceApplicationBuilder
+
+import java.time.{LocalDate, LocalDateTime}
+import java.time.format.DateTimeFormatter
+
+class TimeMachineSpec extends AnyWordSpec with Matchers{
+
+  private val dateFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
+
+
+  "TimeMachine -getCurrentDate" should {
+
+    "Return the configured date specified" in {
+      val app = new GuiceApplicationBuilder().configure(
+        "timemachine.enabled" -> true,
+        "timemachine.date" -> "01-01-2021"
+      ).build()
+
+      val timeMachine = app.injector.instanceOf[TimeMachine]
+      timeMachine.getCurrentDate shouldEqual LocalDate.parse("01-01-2021", dateFormatter)
+    }
+  }
+
+  "Return the current date if timemachine is disabled" in {
+    val app = new GuiceApplicationBuilder().configure(
+      "timemachine.enabled" -> false
+    ).build()
+
+    val timeMachine = app.injector.instanceOf[TimeMachine]
+    timeMachine.getCurrentDate shouldEqual LocalDate.now()
+  }
+
+  "Return the current date if timemachine date set to now" in {
+
+    val app = new GuiceApplicationBuilder().configure(
+      "timemachine.enabled" -> true,
+      "timemachine.date" -> "now"
+    ).build()
+
+    val timeMachine = app.injector.instanceOf[TimeMachine]
+    timeMachine.getCurrentDate shouldEqual LocalDate.now()
+
+  }
+
+  "TimeMachine -getCurrentDateTime" should {
+    "always return the real current date‐time" in {
+      val app = new GuiceApplicationBuilder().build()
+      val tm = app.injector.instanceOf[TimeMachine]
+
+      val now = LocalDateTime.now()
+      val got = tm.getCurrentDateTime
+      java.time.Duration.between(got, now).abs().toSeconds should be < 2L
+    }
+  }
+}


### PR DESCRIPTION
Update application.conf file to contain:

- [ ] A timemachine.enabled flag
- [ ] A timemachine.date String field (all for “now” or string date of format dd/mm/yy“)

Create a new TimeMachineConfig file (or update appConfig) and add:

- [ ] A function to get the optCurrentDate – i.e (if(timemachine is enabled && timemachineDate != “now”) { Parse date string to date and return} else return None

Update the Timemachine class to get the optCurrentDate or use the java current date
